### PR TITLE
Remove bottleneck library 🍼

### DIFF
--- a/utils/DnsLookup.ts
+++ b/utils/DnsLookup.ts
@@ -1,4 +1,3 @@
-import Bottleneck from 'bottleneck';
 import DataLoader from 'dataloader';
 import dnsPacket, {
   type Answer,
@@ -137,11 +136,6 @@ class DnsLookup {
     });
   }
 
-  private limiter = new Bottleneck({
-    maxConcurrent: 10,
-    minTime: 160,
-  });
-
   private requestLoader = new DataLoader<
     {
       domain: string;
@@ -154,9 +148,7 @@ class DnsLookup {
     async (keys) =>
       Promise.all(
         keys.map(async ({ domain, type, nameserver }) =>
-          this.limiter.schedule(() =>
-            this.sendRequest(domain, type, nameserver)
-          )
+          this.sendRequest(domain, type, nameserver)
         )
       ),
     {


### PR DESCRIPTION
Removes the `bottleneck` library to speed up results load times.
Previously added to circumvent ratelimiting from Cloudflare.