### PR TITLE
Set searchParams resolverName as initialValue of ResolverSelector

### DIFF
--- a/app/lookup/[domain]/page.tsx
+++ b/app/lookup/[domain]/page.tsx
@@ -49,7 +49,7 @@ const LookupDomain: FC<LookupDomainProps> = async ({
         <div>
           <div className="flex flex-col gap-1">
             <span className="text-sm text-muted-foreground">Resolver</span>
-            <ResolverSelector />
+            <ResolverSelector initialValue={resolverName} />
           </div>
           <DnsTable records={records} />
         </div>


### PR DESCRIPTION
This fixes the error that if you call up https://digger.tools/lookup/digger.tools?resolver=cloudflare, for example, the Authorative Resolver is still visible selected by default.