### PR TITLE
Filter search suggestions to lookups that returned results 🔍🎯

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -49,16 +49,9 @@ Use the following schema for creating the dataset:
     "fields": []
   },
   {
-    "name": "baseDomain",
+    "name": "hasResults",
     "mode": "NULLABLE",
-    "type": "STRING",
-    "description": null,
-    "fields": []
-  },
-  {
-    "name": "timestamp",
-    "mode": "NULLABLE",
-    "type": "TIMESTAMP",
+    "type": "BOOLEAN",
     "description": null,
     "fields": []
   },
@@ -84,9 +77,16 @@ Use the following schema for creating the dataset:
     "fields": []
   },
   {
-    "name": "hasResults",
+    "name": "baseDomain",
     "mode": "NULLABLE",
-    "type": "BOOLEAN",
+    "type": "STRING",
+    "description": null,
+    "fields": []
+  },
+  {
+    "name": "timestamp",
+    "mode": "NULLABLE",
+    "type": "TIMESTAMP",
     "description": null,
     "fields": []
   }

--- a/SETUP.md
+++ b/SETUP.md
@@ -42,6 +42,13 @@ Use the following schema for creating the dataset:
     "fields": []
   },
   {
+    "name": "lookupType",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": null,
+    "fields": []
+  },
+  {
     "name": "baseDomain",
     "mode": "NULLABLE",
     "type": "STRING",
@@ -108,16 +115,18 @@ GROUP BY
 
 #### Migrating an existing dataset
 
-If you already have a `lookups` table from a previous version that lacks the `hasResults` column, run the following to bring it up to date:
+If you already have a `lookups` table from a previous version that lacks the `hasResults` and `lookupType` columns, run the following to bring it up to date. Note that BigQuery `ADD COLUMN` always appends — existing tables won't have `lookupType` in the second position, but the view and inserts use field names so order doesn't affect correctness.
 
 ```sql
--- Add the new column (NULLABLE so existing rows remain valid).
+-- Add the new columns (NULLABLE so existing rows remain valid).
 ALTER TABLE `project.dataset.lookups`
-ADD COLUMN hasResults BOOL;
+ADD COLUMN hasResults BOOL,
+ADD COLUMN lookupType STRING;
 
 -- Optional: backfill historical rows so popularity isn't reset to zero on
 -- deploy. Skip this if you'd rather have suggestions reflect only post-migration
--- traffic.
+-- traffic. lookupType is left NULL for historical rows since the original
+-- log didn't distinguish lookup kinds.
 UPDATE `project.dataset.lookups`
 SET hasResults = TRUE
 WHERE hasResults IS NULL;

--- a/SETUP.md
+++ b/SETUP.md
@@ -115,39 +115,20 @@ GROUP BY
 
 #### Migrating an existing dataset
 
-If you already have a `lookups` table from a previous version that lacks the `hasResults` and `lookupType` columns, run the following to bring it up to date. Note that BigQuery `ADD COLUMN` always appends — existing tables won't have `lookupType` in the second position, but the view and inserts use field names so order doesn't affect correctness.
+If your `lookups` table predates the `hasResults` and `lookupType` columns, add them and recreate the materialized view above. Optionally backfill `hasResults` so popularity isn't reset on deploy.
 
 ```sql
--- Add the new columns (NULLABLE so existing rows remain valid).
 ALTER TABLE `project.dataset.lookups`
 ADD COLUMN hasResults BOOL,
 ADD COLUMN lookupType STRING;
 
--- Optional: backfill historical rows so popularity isn't reset to zero on
--- deploy. Skip this if you'd rather have suggestions reflect only post-migration
--- traffic. lookupType is left NULL for historical rows since the original
--- log didn't distinguish lookup kinds.
+-- Optional backfill: treat all historical rows as successful lookups.
 UPDATE `project.dataset.lookups`
 SET hasResults = TRUE
 WHERE hasResults IS NULL;
-
--- Recreate the materialized view so it picks up the new WHERE clause.
-CREATE OR REPLACE MATERIALIZED VIEW `project.dataset.popular_domains`
-OPTIONS(
-  refresh_interval_minutes = 360,
-  enable_refresh = true
-) AS
-SELECT
-  baseDomain as domain,
-  COUNT(*) AS count
-FROM
-  `project.dataset.lookups`
-WHERE
-  baseDomain IS NOT NULL
-  AND hasResults = TRUE
-GROUP BY
-  baseDomain;
 ```
+
+Then re-run the `CREATE OR REPLACE MATERIALIZED VIEW` statement from the previous section so the view picks up the new `hasResults` filter.
 
 #### Creating a service account
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -75,6 +75,13 @@ Use the following schema for creating the dataset:
     "type": "BOOLEAN",
     "description": null,
     "fields": []
+  },
+  {
+    "name": "hasResults",
+    "mode": "NULLABLE",
+    "type": "BOOLEAN",
+    "description": null,
+    "fields": []
   }
 ]
 ```
@@ -94,6 +101,41 @@ FROM
   `project.dataset.lookups`
 WHERE
   baseDomain IS NOT NULL
+  AND hasResults = TRUE
+GROUP BY
+  baseDomain;
+```
+
+#### Migrating an existing dataset
+
+If you already have a `lookups` table from a previous version that lacks the `hasResults` column, run the following to bring it up to date:
+
+```sql
+-- Add the new column (NULLABLE so existing rows remain valid).
+ALTER TABLE `project.dataset.lookups`
+ADD COLUMN hasResults BOOL;
+
+-- Optional: backfill historical rows so popularity isn't reset to zero on
+-- deploy. Skip this if you'd rather have suggestions reflect only post-migration
+-- traffic.
+UPDATE `project.dataset.lookups`
+SET hasResults = TRUE
+WHERE hasResults IS NULL;
+
+-- Recreate the materialized view so it picks up the new WHERE clause.
+CREATE OR REPLACE MATERIALIZED VIEW `project.dataset.popular_domains`
+OPTIONS(
+  refresh_interval_minutes = 360,
+  enable_refresh = true
+) AS
+SELECT
+  baseDomain as domain,
+  COUNT(*) AS count
+FROM
+  `project.dataset.lookups`
+WHERE
+  baseDomain IS NOT NULL
+  AND hasResults = TRUE
 GROUP BY
   baseDomain;
 ```

--- a/app/lookup/[domain]/(dns)/page.tsx
+++ b/app/lookup/[domain]/(dns)/page.tsx
@@ -5,6 +5,7 @@ import type { FC } from 'react';
 import { ALL_RECORD_TYPES } from '@/lib/data';
 import { getRecordContextEntries } from '@/lib/record-context';
 import { getResolverFromName } from '@/lib/resolvers/utils';
+import { recordLookupAfter } from '@/lib/search';
 
 import { DnsTable } from './_components/dns-table';
 
@@ -67,6 +68,8 @@ const DnsResultsPage: FC<DnsResultsPageProps> = async ({
       (prev, curr) => prev + curr.records.length,
       0,
     ) > 0;
+
+  await recordLookupAfter(domain, hasResults);
 
   if (!hasResults) {
     notFound();

--- a/app/lookup/[domain]/(dns)/page.tsx
+++ b/app/lookup/[domain]/(dns)/page.tsx
@@ -69,7 +69,7 @@ const DnsResultsPage: FC<DnsResultsPageProps> = async ({
       0,
     ) > 0;
 
-  await recordLookupAfter(domain, hasResults);
+  await recordLookupAfter(domain, 'dns', hasResults);
 
   if (!hasResults) {
     notFound();

--- a/app/lookup/[domain]/certs/page.tsx
+++ b/app/lookup/[domain]/certs/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import type { FC } from 'react';
 
 import { lookupRelatedCerts } from '@/lib/certs';
+import { recordLookupAfter } from '@/lib/search';
 
 import { CertsTable } from './_components/table';
 
@@ -38,6 +39,8 @@ const CertsResultsPage: FC<CertsResultsPageProps> = async (props) => {
   const { domain } = params;
 
   const certs = await lookupRelatedCerts(domain);
+
+  await recordLookupAfter(domain, certs.length > 0);
 
   if (!certs.length) {
     return (

--- a/app/lookup/[domain]/certs/page.tsx
+++ b/app/lookup/[domain]/certs/page.tsx
@@ -40,7 +40,7 @@ const CertsResultsPage: FC<CertsResultsPageProps> = async (props) => {
 
   const certs = await lookupRelatedCerts(domain);
 
-  await recordLookupAfter(domain, certs.length > 0);
+  await recordLookupAfter(domain, 'certs', certs.length > 0);
 
   if (!certs.length) {
     return (

--- a/app/lookup/[domain]/layout.tsx
+++ b/app/lookup/[domain]/layout.tsx
@@ -1,16 +1,12 @@
 import { ExternalLinkIcon } from 'lucide-react';
 import type { Metadata } from 'next';
 import dynamic from 'next/dynamic';
-import { headers } from 'next/headers';
 import { notFound } from 'next/navigation';
-import { after } from 'next/server';
 import { type FC, type ReactNode } from 'react';
 
 import { Card } from '@/components/ui/card';
 
 import { ClientOnly } from '@/components/client-only';
-import { getVisitorIp, isUserBot } from '@/lib/api';
-import { recordLookup } from '@/lib/search';
 import { isValidDomain, isWildcardDomain } from '@/lib/utils';
 
 import { Footer } from '../../_components/footer';
@@ -57,13 +53,6 @@ const LookupLayout: FC<LookupLayoutProps> = async (props) => {
   if (!isValidDomain(domain)) {
     return notFound();
   }
-
-  const headersList = await headers();
-  const ip = getVisitorIp(headersList);
-  const { isBot, userAgent } = isUserBot(headersList);
-  after(async () => {
-    await recordLookup({ domain, ip, userAgent, isBot });
-  });
 
   return (
     <>

--- a/app/lookup/[domain]/subdomains/page.tsx
+++ b/app/lookup/[domain]/subdomains/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 
 import { generateCsv } from '@/lib/csv';
 import { CloudflareDoHResolver } from '@/lib/resolvers/cloudflare';
+import { recordLookupAfter } from '@/lib/search';
 import { findSubdomains } from '@/lib/subdomains';
 
 import { SubdomainsInfoAlert } from './_components/info-alert';
@@ -45,6 +46,8 @@ const SubdomainsResultsPage: FC<SubdomainsResultsPageProps> = async ({
 
   const { results, detailsReduced, detailedResultsLimit } =
     await findSubdomains(domain, new CloudflareDoHResolver());
+
+  await recordLookupAfter(domain, results.length > 0);
 
   const exportFileName = `Domain Digger Subdomains Export ${domain.replaceAll(
     '.',

--- a/app/lookup/[domain]/subdomains/page.tsx
+++ b/app/lookup/[domain]/subdomains/page.tsx
@@ -47,7 +47,7 @@ const SubdomainsResultsPage: FC<SubdomainsResultsPageProps> = async ({
   const { results, detailsReduced, detailedResultsLimit } =
     await findSubdomains(domain, new CloudflareDoHResolver());
 
-  await recordLookupAfter(domain, results.length > 0);
+  await recordLookupAfter(domain, 'subdomains', results.length > 0);
 
   const exportFileName = `Domain Digger Subdomains Export ${domain.replaceAll(
     '.',

--- a/app/lookup/[domain]/whois/page.tsx
+++ b/app/lookup/[domain]/whois/page.tsx
@@ -47,7 +47,7 @@ const WhoisResultsPage: FC<WhoisResultsPageProps> = async ({
   const baseDomain = getBaseDomain(domain);
   const results = await lookupWhois(forceOriginal ? domain : baseDomain);
 
-  await recordLookupAfter(domain, results.length > 0);
+  await recordLookupAfter(domain, 'whois', results.length > 0);
 
   if (results.length === 0) {
     throw new Error('No results found');

--- a/app/lookup/[domain]/whois/page.tsx
+++ b/app/lookup/[domain]/whois/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { type FC, Fragment } from 'react';
 
+import { recordLookupAfter } from '@/lib/search';
 import { getBaseDomain } from '@/lib/utils';
 import { lookupWhois } from '@/lib/whois';
 
@@ -45,6 +46,8 @@ const WhoisResultsPage: FC<WhoisResultsPageProps> = async ({
   const forceOriginal = force !== undefined;
   const baseDomain = getBaseDomain(domain);
   const results = await lookupWhois(forceOriginal ? domain : baseDomain);
+
+  await recordLookupAfter(domain, results.length > 0);
 
   if (results.length === 0) {
     throw new Error('No results found');

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,4 +1,8 @@
+import { headers } from 'next/headers';
+import { after } from 'next/server';
+
 import { env } from '@/env';
+import { getVisitorIp, isUserBot } from '@/lib/api';
 import { bigquery } from '@/lib/bigquery';
 import { getBaseDomain } from '@/lib/utils';
 
@@ -7,6 +11,7 @@ type LookupLogPayload = {
   ip: string;
   userAgent: string | null;
   isBot: boolean;
+  hasResults: boolean;
 };
 
 export const recordLookup = async (payload: LookupLogPayload) => {
@@ -28,6 +33,7 @@ export const recordLookup = async (payload: LookupLogPayload) => {
           ip: payload.ip,
           userAgent: payload.userAgent,
           isBot: payload.isBot,
+          hasResults: payload.hasResults,
         },
       ],
     })
@@ -40,6 +46,19 @@ export const recordLookup = async (payload: LookupLogPayload) => {
         console.error(error);
       }
     });
+};
+
+export const recordLookupAfter = async (
+  domain: string,
+  hasResults: boolean,
+) => {
+  // Resolve headers up-front; the request scope may be torn down inside after().
+  const headersList = await headers();
+  const ip = getVisitorIp(headersList);
+  const { isBot, userAgent } = isUserBot(headersList);
+  after(async () => {
+    await recordLookup({ domain, ip, userAgent, isBot, hasResults });
+  });
 };
 
 export const getSearchSuggestions = async (query: string) => {

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -6,12 +6,15 @@ import { getVisitorIp, isUserBot } from '@/lib/api';
 import { bigquery } from '@/lib/bigquery';
 import { getBaseDomain } from '@/lib/utils';
 
+export type LookupType = 'dns' | 'whois' | 'subdomains' | 'certs';
+
 type LookupLogPayload = {
   domain: string;
   ip: string;
   userAgent: string | null;
   isBot: boolean;
   hasResults: boolean;
+  lookupType: LookupType;
 };
 
 export const recordLookup = async (payload: LookupLogPayload) => {
@@ -28,6 +31,7 @@ export const recordLookup = async (payload: LookupLogPayload) => {
       rows: [
         {
           domain: payload.domain,
+          lookupType: payload.lookupType,
           baseDomain,
           timestamp: Math.floor(new Date().getTime() / 1000),
           ip: payload.ip,
@@ -50,6 +54,7 @@ export const recordLookup = async (payload: LookupLogPayload) => {
 
 export const recordLookupAfter = async (
   domain: string,
+  lookupType: LookupType,
   hasResults: boolean,
 ) => {
   // Resolve headers up-front; the request scope may be torn down inside after().
@@ -57,7 +62,14 @@ export const recordLookupAfter = async (
   const ip = getVisitorIp(headersList);
   const { isBot, userAgent } = isUserBot(headersList);
   after(async () => {
-    await recordLookup({ domain, ip, userAgent, isBot, hasResults });
+    await recordLookup({
+      domain,
+      ip,
+      userAgent,
+      isBot,
+      hasResults,
+      lookupType,
+    });
   });
 };
 

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -10,11 +10,11 @@ export type LookupType = 'dns' | 'whois' | 'subdomains' | 'certs';
 
 type LookupLogPayload = {
   domain: string;
+  lookupType: LookupType;
+  hasResults: boolean;
   ip: string;
   userAgent: string | null;
   isBot: boolean;
-  hasResults: boolean;
-  lookupType: LookupType;
 };
 
 export const recordLookup = async (payload: LookupLogPayload) => {
@@ -32,12 +32,12 @@ export const recordLookup = async (payload: LookupLogPayload) => {
         {
           domain: payload.domain,
           lookupType: payload.lookupType,
-          baseDomain,
-          timestamp: Math.floor(new Date().getTime() / 1000),
+          hasResults: payload.hasResults,
           ip: payload.ip,
           userAgent: payload.userAgent,
           isBot: payload.isBot,
-          hasResults: payload.hasResults,
+          baseDomain,
+          timestamp: Math.floor(new Date().getTime() / 1000),
         },
       ],
     })
@@ -64,11 +64,11 @@ export const recordLookupAfter = async (
   after(async () => {
     await recordLookup({
       domain,
+      lookupType,
+      hasResults,
       ip,
       userAgent,
       isBot,
-      hasResults,
-      lookupType,
     });
   });
 };


### PR DESCRIPTION
## Summary

- Move BigQuery logging from the layout (which fires before any tab knows the result) into each leaf page (DNS, WHOIS, subdomains, certs), so each row carries both a `hasResults` flag and a `lookupType` value.
- Add a `lookupType` column (second in the schema, values `dns` | `whois` | `subdomains` | `certs`) so analytics can attribute success/failure to specific lookup kinds.
- Update the `popular_domains` materialized view to filter `WHERE hasResults = TRUE`, so autocomplete only surfaces domains that actually returned data on at least one lookup type.
- All requests are still logged — only the suggestions view is filtered. Document the schema additions, view DDL, and migration steps in `SETUP.md`.

The map page is intentionally not logged — it's a derived DNS view and would just inflate counts.

## Test plan

- [ ] `pnpm lint` clean (no new warnings)
- [ ] `pnpm test --run` — all tests pass
- [ ] Manual smoke against a real BigQuery dataset:
  - Visit `/lookup/google.com` → row with `lookupType='dns'` and `hasResults=true`
  - Visit `/lookup/<bogus-domain>.com` → 404 page, row with `lookupType='dns'` and `hasResults=false`
  - Visit `/lookup/google.com/whois`, `/subdomains`, `/certs` → rows with the corresponding `lookupType`
  - Refresh `popular_domains` and confirm bogus domain absent
  - `curl /api/search-suggestions?q=<prefix>` returns only domains with results
- [ ] Run the `ALTER TABLE` + view recreation in `SETUP.md` against existing dataset before deploy (note: BigQuery `ADD COLUMN` always appends, so `lookupType` won't be in second position on migrated tables — this is fine since inserts/queries reference fields by name)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filter search suggestions to only domains that returned data. Each lookup page logs `hasResults` and `lookupType`, and the BigQuery `popular_domains` view now filters on `hasResults = TRUE`.

- **New Features**
  - Each results page (DNS, WHOIS, subdomains, certs) calls `recordLookupAfter` with `hasResults` and `lookupType`; layout pre-run logging removed.
  - `/api/search-suggestions` reads from `popular_domains` filtered to successful lookups; the map page is not logged.

- **Migration**
  - Add `hasResults` BOOL and `lookupType` STRING to the `lookups` table.
  - Optionally backfill `hasResults = TRUE`.
  - Recreate the `popular_domains` materialized view with `WHERE hasResults = TRUE`.

<sup>Written for commit d99a19605ca17ba2920df0258d5f1d1f867aeaf5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added post-lookup result recording across DNS, certs, subdomains and WHOIS pages to capture whether lookups returned results.

* **Chores**
  * Extended lookup logging to include lookup type and a has-results flag.
  * Persisted lookup events after page handling to avoid impacting user flow.

* **Documentation**
  * Updated setup and migration guide to add new fields and recreate analytics views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->