### PR TITLE
Address TypeScript 6 deprecations 👴👵

### DIFF
--- a/lib/resolvers/base-doh.test.ts
+++ b/lib/resolvers/base-doh.test.ts
@@ -5,8 +5,10 @@ import { BaseDoHResolver, type DoHResponse } from './base-doh';
 describe('BaseDoHResolver', () => {
   const mockSendRequest = vi.fn();
 
+  class TestDoHResolver extends BaseDoHResolver {}
+
   const mockDoHResponse = (
-    answers: Partial<DoHResponse['Answer'][number]>[] = [],
+    answers: Partial<NonNullable<DoHResponse['Answer']>[number]>[] = [],
   ): DoHResponse => ({
     Status: 0,
     TC: false,
@@ -34,7 +36,7 @@ describe('BaseDoHResolver', () => {
       url: 'https://dns.google/resolve',
     });
 
-    const resolver = new BaseDoHResolver(mockSendRequest);
+    const resolver = new TestDoHResolver(mockSendRequest);
     const records = await resolver.resolveRecordType('example.com', 'A');
 
     expect(records).toEqual({
@@ -58,7 +60,7 @@ describe('BaseDoHResolver', () => {
       url: 'https://dns.google/resolve',
     });
 
-    const resolver = new BaseDoHResolver(mockSendRequest);
+    const resolver = new TestDoHResolver(mockSendRequest);
     const records = await resolver.resolveRecordType('example.com', 'A');
 
     expect(records).toEqual({
@@ -75,7 +77,7 @@ describe('BaseDoHResolver', () => {
       url: 'https://dns.google/resolve',
     });
 
-    const resolver = new BaseDoHResolver(mockSendRequest);
+    const resolver = new TestDoHResolver(mockSendRequest);
 
     await expect(
       resolver.resolveRecordType('example.com', 'A'),

--- a/lib/resolvers/base-doh.ts
+++ b/lib/resolvers/base-doh.ts
@@ -2,7 +2,7 @@ import { RECORD_TYPES_BY_DECIMAL } from '../data';
 import { UserFacingError } from '../user-facing-error';
 import { DnsResolver, type RecordType, type ResolverResponse } from './base';
 
-type DoHResponse = {
+export type DoHResponse = {
   Status: number;
   TC: boolean;
   RD: boolean;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2018",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

Updates the TypeScript compiler target from the deprecated `es5` setting to `es2018` so the project no longer hits the TypeScript 6 deprecation diagnostic.

While verifying the change, `tsc` surfaced narrow resolver test typing issues. This PR exports the DoH response type used by the test and instantiates a concrete test subclass instead of the abstract `BaseDoHResolver`.

## Impact

The TypeScript 6 config deprecation is resolved without suppressing diagnostics via `ignoreDeprecations`, and the affected resolver tests remain type-checkable.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run lib/resolvers/base-doh.test.ts`
- `pnpm test run`
- `pnpm lint` passes with existing warnings only

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the TypeScript `target` from `es5` to `es2018` to resolve the TypeScript 6 deprecation diagnostic. Also fixes resolver test typings by exporting `DoHResponse` and using a concrete `TestDoHResolver`.

- **Bug Fixes**
  - Exported `DoHResponse` from `lib/resolvers/base-doh.ts` for test use.
  - In `base-doh.test.ts`, used `NonNullable<DoHResponse['Answer']>[number]` and a `TestDoHResolver` subclass to satisfy typing.

<sup>Written for commit ff65907e0975bdefc94948b2029021e139fdd7c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored the DNS over HTTPS resolver test suite to improve test infrastructure and type accuracy for mock data.

* **Chores**
  * Updated TypeScript compiler target from es5 to es2018 to enable modern JavaScript language features and improve overall codebase compatibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wotschofsky/domain-digger/pull/66)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->