### PR TITLE
Bypass Vercel Deployment Protection for self-referencing resolver calls 🔓🛡️

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,11 @@ SITE_URL=https://example.com
 # Secret used to authenticate internal API calls
 INTERNAL_API_SECRET=secret
 
+# Vercel Deployment Protection bypass secret; required so self-referencing API calls
+# can pass the firewall on protected (e.g. preview) deployments. Generated under
+# Project Settings → Deployment Protection → Protection Bypass for Automation.
+VERCEL_AUTOMATION_BYPASS_SECRET=
+
 # Plausible Analytics Configuration
 NEXT_PUBLIC_PLAUSIBLE_DOMAIN=example.com
 NEXT_PUBLIC_PLAUSIBLE_HOST=https://customplausible.io # Optional if using plausible.io

--- a/env.ts
+++ b/env.ts
@@ -17,7 +17,6 @@ export const env = createEnv({
 
     SITE_URL: z.string().url().optional(),
     INTERNAL_API_SECRET: z.string().min(1),
-    VERCEL_AUTOMATION_BYPASS_SECRET: z.string().optional(),
 
     GOOGLE_SERVICE_KEY_B64: z.string().optional(),
     BIGQUERY_DATASET: z.string().optional(),

--- a/env.ts
+++ b/env.ts
@@ -17,6 +17,7 @@ export const env = createEnv({
 
     SITE_URL: z.string().url().optional(),
     INTERNAL_API_SECRET: z.string().min(1),
+    VERCEL_AUTOMATION_BYPASS_SECRET: z.string().optional(),
 
     GOOGLE_SERVICE_KEY_B64: z.string().optional(),
     BIGQUERY_DATASET: z.string().optional(),

--- a/lib/resolvers/internal.ts
+++ b/lib/resolvers/internal.ts
@@ -27,15 +27,22 @@ export class InternalDoHResolver extends DnsResolver {
   }
 
   private get requestInit() {
-    if (!env.INTERNAL_API_SECRET) {
+    const headers: Record<string, string> = {};
+
+    if (env.INTERNAL_API_SECRET) {
+      headers.Authorization = env.INTERNAL_API_SECRET;
+    }
+
+    if (env.VERCEL_AUTOMATION_BYPASS_SECRET) {
+      headers['x-vercel-protection-bypass'] =
+        env.VERCEL_AUTOMATION_BYPASS_SECRET;
+    }
+
+    if (Object.keys(headers).length === 0) {
       return {};
     }
 
-    return {
-      headers: {
-        Authorization: env.INTERNAL_API_SECRET,
-      },
-    };
+    return { headers };
   }
 
   public async resolveRecordType(


### PR DESCRIPTION
## Summary
- The `InternalDoHResolver` makes recursive HTTP calls to `/api/internal/resolve/*` on the deployment URL. On Vercel preview deployments with Deployment Protection enabled, these self-calls are blocked by the firewall.
- Added a new optional `VERCEL_AUTOMATION_BYPASS_SECRET` env var. When set, it is sent via the standard `x-vercel-protection-bypass` header alongside the existing `Authorization` header.
- Documented the variable in `.env.example`. Generate the secret under Project Settings → Deployment Protection → Protection Bypass for Automation, then add it to the Vercel project (Preview scope).

## Test plan
- [x] `pnpm test` — existing 97 tests pass; mock for `@/env` doesn't set the new var, so the new header is omitted (backward compatible).
- [ ] Deploy to a protected preview, set `VERCEL_AUTOMATION_BYPASS_SECRET`, run a DNS lookup, and confirm the recursive resolver fetch returns 200 instead of being blocked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bypass Vercel Deployment Protection for self-calls from the internal DNS resolver by sending `x-vercel-protection-bypass` when configured. Fixes blocked recursive resolution on protected preview deployments without impacting other environments.

- **New Features**
  - Added optional `VERCEL_AUTOMATION_BYPASS_SECRET`; when set, requests include `x-vercel-protection-bypass` alongside `Authorization`. Backward compatible; headers are omitted if unset.
  - Dropped redundant server schema for `VERCEL_AUTOMATION_BYPASS_SECRET`; rely on `@t3-oss/env-nextjs` `vercel()` preset.

- **Migration**
  - In Vercel → Project Settings → Deployment Protection → Protection Bypass for Automation, generate a secret and set `VERCEL_AUTOMATION_BYPASS_SECRET` (Preview scope). No action needed if not using protected previews.

<sup>Written for commit a180ac047058b12de170b56ae75e22867b83a9f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added optional environment variable support for bypassing Vercel deployment protection in preview environments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wotschofsky/domain-digger/pull/68)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->