### PR TITLE
Add skeleton placeholder for map in IP details modal 🗺️💀

### DIFF
--- a/app/_components/ip-details-modal.tsx
+++ b/app/_components/ip-details-modal.tsx
@@ -18,6 +18,7 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from '@/components/ui/drawer';
+import { Skeleton } from '@/components/ui/skeleton';
 import { Spinner } from '@/components/ui/spinner';
 import { Table, TableBody, TableCell, TableRow } from '@/components/ui/table';
 
@@ -33,6 +34,7 @@ const LocationMap = dynamic(
     })),
   {
     ssr: false,
+    loading: () => <Skeleton className="size-full rounded-none" />,
   },
 );
 
@@ -131,7 +133,7 @@ export const IpDetailsModal: FC<IpDetailsModalProps> = ({
         </Table>
 
         {location && (
-          <div className="my-4 [&_.leaflet-container]:h-80 [&_.leaflet-container]:w-full">
+          <div className="my-4 h-80 w-full [&_.leaflet-container]:size-full">
             <LocationMap location={location} />
           </div>
         )}


### PR DESCRIPTION
## Summary
- The map wrapper in the IP details modal only sized itself via the inner `.leaflet-container` selector, so the slot collapsed to zero height until the dynamically imported map chunk finished loading. This caused visible content shift when the map appeared.
- Move the dimensions (`h-80 w-full`) onto the wrapper itself so the slot is reserved upfront, regardless of whether the inner leaflet container has mounted.
- Pass a `Skeleton` placeholder via `dynamic()`'s `loading` prop. It fills the reserved slot (`size-full`) with `rounded-none` to match the map's sharp corners for a seamless swap.

## Test plan
- [ ] Open the IP details modal for any IP with location coordinates
- [ ] Verify a skeleton placeholder with the exact map dimensions appears immediately when the data loads
- [ ] Verify the skeleton smoothly transitions to the map without any layout shift in the modal
- [ ] Verify the modal still renders correctly for IPs without coordinates (no map / no skeleton shown)
- [ ] Verify behavior in both the desktop dialog and mobile drawer variants

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent layout shift in the IP details modal by reserving the map area and showing a skeleton while the map chunk loads. The wrapper now sets fixed dimensions (h-80 w-full), and `dynamic()` renders a full-size `Skeleton` with square corners until the Leaflet container mounts; no placeholder is shown when the IP lacks coordinates.

<sup>Written for commit 3613647aec137b2c3d358486d991ee156a6e4ce4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated map container styling for improved layout consistency.

* **New Features**
  * Enhanced location map loading experience with skeleton loading state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wotschofsky/domain-digger/pull/72)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->