### PR TITLE
Fix IP details modal overflowing on long reverse hostnames 📏✂️

### DIFF
--- a/app/_components/ip-details-modal.tsx
+++ b/app/_components/ip-details-modal.tsx
@@ -124,7 +124,7 @@ export const IpDetailsModal: FC<IpDetailsModalProps> = ({
             {mappedEntries.map((el) => (
               <TableRow key={el.label} className="hover:bg-transparent">
                 <TableCell className="pl-0">{el.label}</TableCell>
-                <TableCell className="wrap-anywhere pr-0 whitespace-normal">
+                <TableCell className="pr-0 wrap-anywhere whitespace-normal">
                   {el.component}
                 </TableCell>
               </TableRow>

--- a/app/_components/ip-details-modal.tsx
+++ b/app/_components/ip-details-modal.tsx
@@ -124,7 +124,7 @@ export const IpDetailsModal: FC<IpDetailsModalProps> = ({
             {mappedEntries.map((el) => (
               <TableRow key={el.label} className="hover:bg-transparent">
                 <TableCell className="pl-0">{el.label}</TableCell>
-                <TableCell className="wrap-break-words pr-0 whitespace-normal">
+                <TableCell className="wrap-anywhere pr-0 whitespace-normal">
                   {el.component}
                 </TableCell>
               </TableRow>


### PR DESCRIPTION
## Summary
- Long reverse DNS hostnames (e.g. `a95-100-248-10.deploy.static.akamaitechnologies.com`) were stretching the IP details modal past `max-w-lg` and widening the map at the bottom along with it.
- Root cause: the cell used `wrap-break-words` (`overflow-wrap: break-word`), which doesn't shrink min-content — so the dialog's grid item was forced wider by the unbreakable string.
- Switched the cell to `wrap-anywhere` (`overflow-wrap: anywhere`), which breaks at any character and reduces min-content, keeping the dialog and map at their intended widths.

## Test plan
- [ ] Open the IP details modal for an IP whose reverse DNS is a long hostname; confirm the value wraps and the modal stays at `max-w-lg`.
- [ ] Confirm the map at the bottom of the modal stays at the dialog's width.
- [ ] Spot-check shorter reverse values still render unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes IP details modal overflow on long unbreakable strings (e.g. reverse DNS hostnames) by switching the value cell to `wrap-anywhere`. Text now wraps at any character, keeping the dialog and map within `max-w-lg`.

<sup>Written for commit 9bb9a7d0357638518622bcf1a8fe72033e8c38b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved text-wrapping in the IP details table so long strings, coordinates, and links break more naturally within value cells for clearer display and fewer layout overflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wotschofsky/domain-digger/pull/73)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->