### PR TITLE
Replace IP details modal spinner with skeleton loader 🦴⏳

### DIFF
--- a/app/_components/ip-details-modal.tsx
+++ b/app/_components/ip-details-modal.tsx
@@ -3,7 +3,7 @@ import { useWindowSize } from '@uidotdev/usehooks';
 import type { LatLngTuple } from 'leaflet';
 import naturalCompare from 'natural-compare-lite';
 import dynamic from 'next/dynamic';
-import type { FC } from 'react';
+import { type FC, Fragment, type ReactNode } from 'react';
 import useSWRImmutable from 'swr/immutable';
 
 import {
@@ -19,7 +19,6 @@ import {
   DrawerTitle,
 } from '@/components/ui/drawer';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Spinner } from '@/components/ui/spinner';
 import { Table, TableBody, TableCell, TableRow } from '@/components/ui/table';
 
 import type { IpLookupResponse } from '@/app/api/ip-details/route';
@@ -44,6 +43,22 @@ type IpDetailsModalProps = {
   onOpenChange: DialogProps['onOpenChange'];
 };
 
+const Unknown: FC = () => <span className="italic">unknown</span>;
+
+const renderField = (
+  value: string | null | undefined,
+  skeletonClassName: string,
+  isLoading: boolean,
+) => {
+  if (isLoading) {
+    return <Skeleton className={`inline-block h-4 ${skeletonClassName}`} />;
+  }
+  if (!value) {
+    return <Unknown />;
+  }
+  return <span>{value}</span>;
+};
+
 export const IpDetailsModal: FC<IpDetailsModalProps> = ({
   ip,
   open,
@@ -61,15 +76,38 @@ export const IpDetailsModal: FC<IpDetailsModalProps> = ({
       return <p className="my-12 text-center">An error occurred!</p>;
     }
 
-    if (!data) {
-      return (
-        <div className="flex items-center justify-center">
-          <Spinner className="my-8" />
-        </div>
-      );
-    }
+    const isLoading = !data;
 
-    const mappedEntries = [
+    const reverseComponent = (() => {
+      if (isLoading) {
+        return <Skeleton className="inline-block h-4 w-64" />;
+      }
+      if (!data.reverse.length) {
+        return <Unknown />;
+      }
+      const sorted = data.reverse.slice().sort(naturalCompare);
+      return (
+        <>
+          {sorted.map((address, idx) => (
+            <Fragment key={address}>
+              <DomainLink domain={address} />
+              {idx < sorted.length - 1 && <span>, </span>}
+            </Fragment>
+          ))}
+        </>
+      );
+    })();
+
+    const locationText = data
+      ? [data.country, data.region, data.city].filter(Boolean).join(', ')
+      : '';
+
+    const coordinatesText =
+      data && data.lat && data.lon
+        ? `Latitude: ${data.lat}; Longitude: ${data.lon}`
+        : '';
+
+    const entries: { label: string; component: ReactNode }[] = [
       {
         label: 'IP',
         component: (
@@ -79,49 +117,40 @@ export const IpDetailsModal: FC<IpDetailsModalProps> = ({
           </>
         ),
       },
-      ...data.reverse
-        .slice()
-        .sort(naturalCompare)
-        .map((address) => ({
-          label: 'Reverse',
-          component: <DomainLink domain={address} />,
-        })),
-      ...addIf(!!data.org, {
+      {
+        label: 'Reverse',
+        component: reverseComponent,
+      },
+      {
         label: 'Organization',
-        component: <span>{data.org}</span>,
-      }),
-      ...addIf(!!data.isp, {
+        component: renderField(data?.org, 'w-48', isLoading),
+      },
+      {
         label: 'ISP',
-        component: <span>{data.isp}</span>,
-      }),
-      ...addIf(!!data.country || !!data.region || !!data.city, {
+        component: renderField(data?.isp, 'w-24', isLoading),
+      },
+      {
         label: 'Location',
-        component: (
-          <span>
-            {[data.country, data.region, data.city].filter(Boolean).join(', ')}
-          </span>
-        ),
-      }),
-      ...addIf(!!data.lat && !!data.lon, {
+        component: renderField(locationText || null, 'w-56', isLoading),
+      },
+      {
         label: 'Coordinates',
-        component: (
-          <span>{`Latitude: ${data.lat}; Longitude: ${data.lon}`}</span>
-        ),
-      }),
-      ...addIf(!!data.timezone, {
+        component: renderField(coordinatesText || null, 'w-60', isLoading),
+      },
+      {
         label: 'Timezone',
-        component: <span>{data.timezone}</span>,
-      }),
+        component: renderField(data?.timezone, 'w-32', isLoading),
+      },
     ];
 
     const location =
-      data.lat && data.lon ? ([data.lat, data.lon] as LatLngTuple) : null;
+      data?.lat && data?.lon ? ([data.lat, data.lon] as LatLngTuple) : null;
 
     return (
       <>
         <Table>
           <TableBody>
-            {mappedEntries.map((el) => (
+            {entries.map((el) => (
               <TableRow key={el.label} className="hover:bg-transparent">
                 <TableCell className="pl-0">{el.label}</TableCell>
                 <TableCell className="pr-0 wrap-anywhere whitespace-normal">
@@ -165,7 +194,3 @@ export const IpDetailsModal: FC<IpDetailsModalProps> = ({
     </Dialog>
   );
 };
-
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
-const addIf = <T extends unknown>(condition: boolean, value: T): T[] =>
-  condition ? [value] : [];

--- a/app/_components/ip-details-modal.tsx
+++ b/app/_components/ip-details-modal.tsx
@@ -43,11 +43,15 @@ type IpDetailsModalProps = {
   onOpenChange: DialogProps['onOpenChange'];
 };
 
-const renderField = (
-  value: string | null | undefined,
-  skeletonClassName: string,
-  isLoading: boolean,
-) =>
+const renderField = ({
+  value,
+  skeletonClassName,
+  isLoading,
+}: {
+  value: string | null | undefined;
+  skeletonClassName: string;
+  isLoading: boolean;
+}) =>
   isLoading ? (
     <Skeleton className={`inline-block h-4 ${skeletonClassName}`} />
   ) : (
@@ -71,17 +75,6 @@ export const IpDetailsModal: FC<IpDetailsModalProps> = ({
       return <p className="my-12 text-center">An error occurred!</p>;
     }
 
-    const isLoading = !data;
-    const reverse = data?.reverse.slice().sort(naturalCompare) ?? [];
-    const locationText = data
-      ? [data.country, data.region, data.city].filter(Boolean).join(', ')
-      : '';
-
-    const coordinatesText =
-      data?.lat != null && data.lon != null
-        ? `Latitude: ${data.lat}; Longitude: ${data.lon}`
-        : '';
-
     const entries = [
       {
         label: 'IP',
@@ -94,13 +87,13 @@ export const IpDetailsModal: FC<IpDetailsModalProps> = ({
       },
       {
         label: 'Reverse',
-        component: isLoading ? (
+        component: !data ? (
           <Skeleton className="inline-block h-4 w-64" />
-        ) : reverse.length ? (
-          reverse.map((address, index) => (
+        ) : data?.reverse.length ? (
+          data?.reverse.toSorted(naturalCompare).map((address, index) => (
             <span key={address}>
               <DomainLink domain={address} />
-              {index < reverse.length - 1 && ', '}
+              {index < data.reverse.length - 1 && ', '}
             </span>
           ))
         ) : (
@@ -109,23 +102,48 @@ export const IpDetailsModal: FC<IpDetailsModalProps> = ({
       },
       {
         label: 'Organization',
-        component: renderField(data?.org, 'w-48', isLoading),
+        component: renderField({
+          value: data?.org,
+          skeletonClassName: 'w-48',
+          isLoading: !data,
+        }),
       },
       {
         label: 'ISP',
-        component: renderField(data?.isp, 'w-24', isLoading),
+        component: renderField({
+          value: data?.isp,
+          skeletonClassName: 'w-24',
+          isLoading: !data,
+        }),
       },
       {
         label: 'Location',
-        component: renderField(locationText || null, 'w-56', isLoading),
+        component: renderField({
+          value: data
+            ? [data.country, data.region, data.city].filter(Boolean).join(', ')
+            : null,
+          skeletonClassName: 'w-56',
+          isLoading: !data,
+        }),
       },
       {
         label: 'Coordinates',
-        component: renderField(coordinatesText || null, 'w-60', isLoading),
+        component: renderField({
+          value:
+            data?.lat != null && data.lon != null
+              ? `Latitude: ${data.lat}; Longitude: ${data.lon}`
+              : null,
+          skeletonClassName: 'w-60',
+          isLoading: !data,
+        }),
       },
       {
         label: 'Timezone',
-        component: renderField(data?.timezone, 'w-32', isLoading),
+        component: renderField({
+          value: data?.timezone,
+          skeletonClassName: 'w-32',
+          isLoading: !data,
+        }),
       },
     ];
 
@@ -149,9 +167,9 @@ export const IpDetailsModal: FC<IpDetailsModalProps> = ({
           </TableBody>
         </Table>
 
-        {(isLoading || location) && (
+        {(!data || location) && (
           <div className="my-4 h-80 w-full [&_.leaflet-container]:size-full">
-            {isLoading ? (
+            {!data ? (
               <Skeleton className="size-full rounded-none" />
             ) : location ? (
               <LocationMap location={location} />

--- a/app/_components/ip-details-modal.tsx
+++ b/app/_components/ip-details-modal.tsx
@@ -3,7 +3,7 @@ import { useWindowSize } from '@uidotdev/usehooks';
 import type { LatLngTuple } from 'leaflet';
 import naturalCompare from 'natural-compare-lite';
 import dynamic from 'next/dynamic';
-import { type FC, Fragment, type ReactNode } from 'react';
+import type { FC } from 'react';
 import useSWRImmutable from 'swr/immutable';
 
 import {
@@ -22,7 +22,6 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Table, TableBody, TableCell, TableRow } from '@/components/ui/table';
 
 import type { IpLookupResponse } from '@/app/api/ip-details/route';
-import { cn } from '@/lib/utils';
 
 import { CopyButton } from './copy-button';
 import { DomainLink } from './domain-link';
@@ -44,23 +43,16 @@ type IpDetailsModalProps = {
   onOpenChange: DialogProps['onOpenChange'];
 };
 
-const UnknownText: FC<{ displayText?: string }> = ({
-  displayText = 'unknown',
-}) => <span className="italic">{displayText}</span>;
-
 const renderField = (
   value: string | null | undefined,
   skeletonClassName: string,
   isLoading: boolean,
-) => {
-  if (isLoading) {
-    return <Skeleton className={cn('inline-block h-4', skeletonClassName)} />;
-  }
-  if (!value) {
-    return <UnknownText />;
-  }
-  return <span>{value}</span>;
-};
+) =>
+  isLoading ? (
+    <Skeleton className={`inline-block h-4 ${skeletonClassName}`} />
+  ) : (
+    value || <span className="italic">unknown</span>
+  );
 
 export const IpDetailsModal: FC<IpDetailsModalProps> = ({
   ip,
@@ -80,37 +72,17 @@ export const IpDetailsModal: FC<IpDetailsModalProps> = ({
     }
 
     const isLoading = !data;
-
-    const reverseComponent = (() => {
-      if (isLoading) {
-        return <Skeleton className="inline-block h-4 w-64" />;
-      }
-      if (!data.reverse.length) {
-        return <UnknownText displayText="not configured" />;
-      }
-      const sorted = data.reverse.slice().sort(naturalCompare);
-      return (
-        <>
-          {sorted.map((address, idx) => (
-            <Fragment key={address}>
-              <DomainLink domain={address} />
-              {idx < sorted.length - 1 && <span>, </span>}
-            </Fragment>
-          ))}
-        </>
-      );
-    })();
-
+    const reverse = data?.reverse.slice().sort(naturalCompare) ?? [];
     const locationText = data
       ? [data.country, data.region, data.city].filter(Boolean).join(', ')
       : '';
 
     const coordinatesText =
-      data && data.lat != null && data.lon != null
+      data?.lat != null && data.lon != null
         ? `Latitude: ${data.lat}; Longitude: ${data.lon}`
         : '';
 
-    const entries: { label: string; component: ReactNode }[] = [
+    const entries = [
       {
         label: 'IP',
         component: (
@@ -122,7 +94,18 @@ export const IpDetailsModal: FC<IpDetailsModalProps> = ({
       },
       {
         label: 'Reverse',
-        component: reverseComponent,
+        component: isLoading ? (
+          <Skeleton className="inline-block h-4 w-64" />
+        ) : reverse.length ? (
+          reverse.map((address, index) => (
+            <span key={address}>
+              <DomainLink domain={address} />
+              {index < reverse.length - 1 && ', '}
+            </span>
+          ))
+        ) : (
+          <span className="italic">not configured</span>
+        ),
       },
       {
         label: 'Organization',
@@ -147,7 +130,7 @@ export const IpDetailsModal: FC<IpDetailsModalProps> = ({
     ];
 
     const location =
-      data?.lat != null && data?.lon != null
+      data?.lat != null && data.lon != null
         ? ([data.lat, data.lon] as LatLngTuple)
         : null;
 

--- a/app/_components/ip-details-modal.tsx
+++ b/app/_components/ip-details-modal.tsx
@@ -103,7 +103,7 @@ export const IpDetailsModal: FC<IpDetailsModalProps> = ({
       : '';
 
     const coordinatesText =
-      data && data.lat && data.lon
+      data && data.lat != null && data.lon != null
         ? `Latitude: ${data.lat}; Longitude: ${data.lon}`
         : '';
 
@@ -144,7 +144,7 @@ export const IpDetailsModal: FC<IpDetailsModalProps> = ({
     ];
 
     const location =
-      data?.lat && data?.lon ? ([data.lat, data.lon] as LatLngTuple) : null;
+      data?.lat != null && data?.lon != null ? ([data.lat, data.lon] as LatLngTuple) : null;
 
     return (
       <>

--- a/app/_components/ip-details-modal.tsx
+++ b/app/_components/ip-details-modal.tsx
@@ -22,6 +22,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Table, TableBody, TableCell, TableRow } from '@/components/ui/table';
 
 import type { IpLookupResponse } from '@/app/api/ip-details/route';
+import { cn } from '@/lib/utils';
 
 import { CopyButton } from './copy-button';
 import { DomainLink } from './domain-link';
@@ -51,7 +52,7 @@ const renderField = (
   isLoading: boolean,
 ) => {
   if (isLoading) {
-    return <Skeleton className={`inline-block h-4 ${skeletonClassName}`} />;
+    return <Skeleton className={cn('inline-block h-4', skeletonClassName)} />;
   }
   if (!value) {
     return <Unknown />;
@@ -144,7 +145,9 @@ export const IpDetailsModal: FC<IpDetailsModalProps> = ({
     ];
 
     const location =
-      data?.lat != null && data?.lon != null ? ([data.lat, data.lon] as LatLngTuple) : null;
+      data?.lat != null && data?.lon != null
+        ? ([data.lat, data.lon] as LatLngTuple)
+        : null;
 
     return (
       <>

--- a/app/_components/ip-details-modal.tsx
+++ b/app/_components/ip-details-modal.tsx
@@ -86,7 +86,7 @@ export const IpDetailsModal: FC<IpDetailsModalProps> = ({
         return <Skeleton className="inline-block h-4 w-64" />;
       }
       if (!data.reverse.length) {
-        return <UnknownText displayText="not set" />;
+        return <UnknownText displayText="not configured" />;
       }
       const sorted = data.reverse.slice().sort(naturalCompare);
       return (

--- a/app/_components/ip-details-modal.tsx
+++ b/app/_components/ip-details-modal.tsx
@@ -161,9 +161,13 @@ export const IpDetailsModal: FC<IpDetailsModalProps> = ({
           </TableBody>
         </Table>
 
-        {location && (
+        {(isLoading || location) && (
           <div className="my-4 h-80 w-full [&_.leaflet-container]:size-full">
-            <LocationMap location={location} />
+            {isLoading ? (
+              <Skeleton className="size-full rounded-none" />
+            ) : location ? (
+              <LocationMap location={location} />
+            ) : null}
           </div>
         )}
       </>

--- a/app/_components/ip-details-modal.tsx
+++ b/app/_components/ip-details-modal.tsx
@@ -44,7 +44,9 @@ type IpDetailsModalProps = {
   onOpenChange: DialogProps['onOpenChange'];
 };
 
-const Unknown: FC = () => <span className="italic">unknown</span>;
+const UnknownText: FC<{ displayText?: string }> = ({
+  displayText = 'unknown',
+}) => <span className="italic">{displayText}</span>;
 
 const renderField = (
   value: string | null | undefined,
@@ -55,7 +57,7 @@ const renderField = (
     return <Skeleton className={cn('inline-block h-4', skeletonClassName)} />;
   }
   if (!value) {
-    return <Unknown />;
+    return <UnknownText />;
   }
   return <span>{value}</span>;
 };
@@ -84,7 +86,7 @@ export const IpDetailsModal: FC<IpDetailsModalProps> = ({
         return <Skeleton className="inline-block h-4 w-64" />;
       }
       if (!data.reverse.length) {
-        return <Unknown />;
+        return <UnknownText displayText="not set" />;
       }
       const sorted = data.reverse.slice().sort(naturalCompare);
       return (


### PR DESCRIPTION
## Summary
Refactored the IP details modal component to improve handling of loading states, eliminate conditional array spreading, and enhance code maintainability.

## Key Changes
- **Removed Spinner component**: Replaced the loading spinner with skeleton loaders that match the actual field widths, providing better visual feedback during data loading
- **Introduced `renderField` helper**: Created a reusable function to consistently handle loading, empty, and populated states across all data fields
- **Refactored reverse DNS rendering**: Moved reverse DNS address rendering into a dedicated `reverseComponent` variable with proper loading and empty states
- **Eliminated `addIf` utility**: Removed the conditional array spreading pattern and replaced it with a static entries array, improving code readability
- **Added `Unknown` component**: Created a dedicated component for displaying "unknown" values with consistent styling
- **Improved data preparation**: Pre-computed location and coordinates text outside the entries array for cleaner code organization
- **Enhanced imports**: Added `Fragment` and `ReactNode` imports to support the refactored structure

## Implementation Details
- The `renderField` function handles three states: loading (skeleton), empty (Unknown component), and populated (span with value)
- Skeleton widths are customized per field to match expected content width
- The reverse DNS component now properly displays multiple addresses with comma separation and handles loading/empty states
- All entries are now statically defined, making the component structure more predictable and easier to maintain

https://claude.ai/code/session_01T98h1WCFBxde9c1bKbtSbv

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the spinner in the IP details modal with per-field skeletons and unified field rendering for a clearer, faster-loading UI. Polished the map area to show a full-bleed skeleton and only render the map when coordinates exist.

- **Refactors**
  - Show row labels and IP immediately; per-field skeletons with tailored widths; italic "unknown" for missing values.
  - Added `renderField` helper for consistent loading/empty/value states; removed `Spinner`.
  - Consolidated reverse DNS into a single, comma-separated row with natural sorting; label is now "Reverse" and shows "not configured" when empty.
  - Render the map area while loading and only when coordinates exist; use a full-size, square-corner skeleton during load.
  - Replaced conditional array spreading with a static entries list; precomputed location/coordinates; null-safe lat/lon checks.

<sup>Written for commit 8005f080fb00238f004657092a3e8eecca1f9848. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Per-field loading now shows skeletons and "unknown" placeholders instead of a single centered spinner.
  * Reverse field displays a skeleton while loading, shows "not configured" when empty, or a natural-sorted, comma-separated domain list when present.
  * Details table rebuilt from a fixed set of rows for consistent ordering and predictable rendering.
  * Map area shows a full skeleton while loading and only renders the map when coordinates are available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wotschofsky/domain-digger/pull/74)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->