### PR TITLE
Make INTERNAL_API_SECRET optional in dev 🕵️🔓

### DIFF
--- a/env.ts
+++ b/env.ts
@@ -16,7 +16,10 @@ export const env = createEnv({
     NODE_ENV: z.enum(['development', 'production', 'test']).optional(),
 
     SITE_URL: z.string().url().optional(),
-    INTERNAL_API_SECRET: z.string().min(1),
+    INTERNAL_API_SECRET:
+      process.env.NODE_ENV === 'development'
+        ? z.string().min(1).default('dev-internal-api-secret')
+        : z.string().min(1),
 
     GOOGLE_SERVICE_KEY_B64: z.string().optional(),
     BIGQUERY_DATASET: z.string().optional(),


### PR DESCRIPTION
## Summary
Updated the environment variable validation for `INTERNAL_API_SECRET` to provide a default value in development mode, making local development easier without requiring manual configuration.

## Key Changes
- Modified `INTERNAL_API_SECRET` validation to conditionally apply different schemas based on `NODE_ENV`
- In development: provides a default value of `'dev-internal-api-secret'` while still requiring a non-empty string
- In production/test: maintains the original strict requirement of a non-empty string with no default

## Implementation Details
The change uses a ternary operator to branch the Zod schema definition based on the current environment. This allows developers to run the application locally without explicitly setting `INTERNAL_API_SECRET`, while still enforcing the requirement in production environments where a real secret must be provided.

https://claude.ai/code/session_019bRYbUEttiW5sy3q816ttk

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default `INTERNAL_API_SECRET` to `dev-internal-api-secret` in development to simplify local setup. Production and test still require a non-empty `INTERNAL_API_SECRET` with no default.

<sup>Written for commit 5aacdd823ebed1528e146ec664bc27e8236d16c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified local development setup by providing a default value for the internal API secret in development environments, while maintaining security requirements in production and other environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wotschofsky/domain-digger/pull/75)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->