### PR TITLE
Fix IPv6 reverse-DNS expansion edge cases 🔄🔍

### DIFF
--- a/lib/ips.test.ts
+++ b/lib/ips.test.ts
@@ -19,8 +19,55 @@ describe('ipv4ToDnsName', () => {
 describe('ipv6ToDnsName', () => {
   it('should convert an IPv6 address to a reverse DNS lookup format', () => {
     expect(ipv6ToDnsName('2001:db8::1')).toBe(
-      '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa',
+      '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa',
     );
+  });
+
+  it('should convert a fully expanded IPv6 address to a reverse DNS lookup format', () => {
+    expect(ipv6ToDnsName('2001:0db8:85a3:0000:0000:8a2e:0370:7334')).toBe(
+      '4.3.3.7.0.7.3.0.e.2.a.8.0.0.0.0.0.0.0.0.3.a.5.8.8.b.d.0.1.0.0.2.ip6.arpa',
+    );
+  });
+
+  it('should expand "::" to all-zero hextets', () => {
+    expect(ipv6ToDnsName('::')).toBe(
+      '0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa',
+    );
+  });
+
+  it('should expand a leading "::" prefix', () => {
+    expect(ipv6ToDnsName('::1')).toBe(
+      '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa',
+    );
+  });
+
+  it('should expand a trailing "::" suffix', () => {
+    expect(ipv6ToDnsName('2001:db8::')).toBe(
+      '0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa',
+    );
+  });
+
+  it('should produce exactly 32 nibbles for any valid IPv6 address', () => {
+    const inputs = [
+      '2001:db8::1',
+      '::',
+      '::1',
+      '2001:db8::',
+      '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+      'fe80::250:56ff:fe97:2b82',
+      'abcd:ef01::3456:7890',
+    ];
+
+    for (const ip of inputs) {
+      expect(isIP(ip), `precondition: ${ip} is a valid IP`).toBe(true);
+      const name = ipv6ToDnsName(ip);
+      expect(name.endsWith('.ip6.arpa'), `${ip} -> ${name}`).toBe(true);
+      const nibbles = name.slice(0, -'.ip6.arpa'.length).split('.');
+      expect(nibbles.length, `${ip} -> ${name}`).toBe(32);
+      for (const nibble of nibbles) {
+        expect(nibble, `${ip} -> ${name}`).toMatch(/^[0-9a-f]$/);
+      }
+    }
   });
 });
 
@@ -31,7 +78,7 @@ describe('ipToDnsName', () => {
 
   it('should convert an IPv6 address to a reverse DNS lookup format', () => {
     expect(ipToDnsName('2001:db8::1')).toBe(
-      '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa',
+      '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa',
     );
   });
 });

--- a/lib/ips.test.ts
+++ b/lib/ips.test.ts
@@ -11,14 +11,28 @@ import {
 } from './ips';
 
 describe('ipv4ToDnsName', () => {
+  // Intentionally omit the trailing root dot: these names are used as DNS query
+  // inputs, not DNS master-file absolute-name presentation strings.
   it('should convert an IPv4 address to a reverse DNS lookup format', () => {
     expect(ipv4ToDnsName('8.8.8.8')).toBe('8.8.8.8.in-addr.arpa');
+  });
+
+  it('should reverse non-symmetric IPv4 octets', () => {
+    expect(ipv4ToDnsName('192.0.2.1')).toBe('1.2.0.192.in-addr.arpa');
   });
 });
 
 describe('ipv6ToDnsName', () => {
+  // Intentionally omit the trailing root dot: these names are used as DNS query
+  // inputs, not DNS master-file absolute-name presentation strings.
   it('should convert an IPv6 address to a reverse DNS lookup format', () => {
     expect(ipv6ToDnsName('2001:db8::1')).toBe(
+      '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa',
+    );
+  });
+
+  it('should normalize uppercase IPv6 hex digits to lowercase reverse labels', () => {
+    expect(ipv6ToDnsName('2001:DB8::1')).toBe(
       '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa',
     );
   });
@@ -26,6 +40,30 @@ describe('ipv6ToDnsName', () => {
   it('should convert a fully expanded IPv6 address to a reverse DNS lookup format', () => {
     expect(ipv6ToDnsName('2001:0db8:85a3:0000:0000:8a2e:0370:7334')).toBe(
       '4.3.3.7.0.7.3.0.e.2.a.8.0.0.0.0.0.0.0.0.3.a.5.8.8.b.d.0.1.0.0.2.ip6.arpa',
+    );
+  });
+
+  it('should pad short hextets in an uncompressed IPv6 address', () => {
+    expect(ipv6ToDnsName('2001:db8:1:2:3:4:5:6')).toBe(
+      '6.0.0.0.5.0.0.0.4.0.0.0.3.0.0.0.2.0.0.0.1.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa',
+    );
+  });
+
+  it('should expand :: when it represents exactly one zero hextet', () => {
+    expect(ipv6ToDnsName('2001:db8:0:1::2:3:4')).toBe(
+      '4.0.0.0.3.0.0.0.2.0.0.0.0.0.0.0.1.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa',
+    );
+  });
+
+  it('should convert an IPv4-mapped IPv6 address to a reverse DNS lookup format', () => {
+    expect(ipv6ToDnsName('::ffff:192.0.2.128')).toBe(
+      '0.8.2.0.0.0.0.c.f.f.f.f.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa',
+    );
+  });
+
+  it('should convert an IPv4-embedded IPv6 address to a reverse DNS lookup format', () => {
+    expect(ipv6ToDnsName('2001:db8::192.0.2.33')).toBe(
+      '1.2.2.0.0.0.0.c.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa',
     );
   });
 
@@ -74,6 +112,10 @@ describe('ipv6ToDnsName', () => {
 describe('ipToDnsName', () => {
   it('should convert an IPv4 address to a reverse DNS lookup format', () => {
     expect(ipToDnsName('8.8.8.8')).toBe('8.8.8.8.in-addr.arpa');
+  });
+
+  it('should reverse non-symmetric IPv4 octets', () => {
+    expect(ipToDnsName('192.0.2.1')).toBe('1.2.0.192.in-addr.arpa');
   });
 
   it('should convert an IPv6 address to a reverse DNS lookup format', () => {

--- a/lib/ips.ts
+++ b/lib/ips.ts
@@ -73,11 +73,7 @@ export const ipv6ToDnsName = (ipv6: string) => {
     const headSegments = head ? head.split(':') : [];
     const tailSegments = tail ? tail.split(':') : [];
     const missing = 8 - headSegments.length - tailSegments.length;
-    segments = [
-      ...headSegments,
-      ...Array(missing).fill('0'),
-      ...tailSegments,
-    ];
+    segments = [...headSegments, ...Array(missing).fill('0'), ...tailSegments];
   } else {
     segments = ipv6.split(':');
   }

--- a/lib/ips.ts
+++ b/lib/ips.ts
@@ -67,24 +67,25 @@ export const ipv4ToDnsName = (ipv4: string) =>
   ipv4.split('.').reverse().join('.') + '.in-addr.arpa';
 
 export const ipv6ToDnsName = (ipv6: string) => {
-  const segments = ipv6.split(':');
-  const missingSegments = 8 - segments.length + (ipv6.includes('::') ? 1 : 0);
-  const expandedSegments = segments.map((segment) => segment.padStart(4, '0'));
-  for (let i = 0; i < missingSegments; i++) {
-    expandedSegments.splice(segments.indexOf(''), 0, '0000');
+  let segments: string[];
+  if (ipv6.includes('::')) {
+    const [head, tail] = ipv6.split('::');
+    const headSegments = head ? head.split(':') : [];
+    const tailSegments = tail ? tail.split(':') : [];
+    const missing = 8 - headSegments.length - tailSegments.length;
+    segments = [
+      ...headSegments,
+      ...Array(missing).fill('0'),
+      ...tailSegments,
+    ];
+  } else {
+    segments = ipv6.split(':');
   }
-  const fullAddress = expandedSegments.join('');
+  const fullAddress = segments
+    .map((segment) => segment.padStart(4, '0'))
+    .join('');
 
-  return (
-    fullAddress
-      .split('')
-      .reverse()
-      .join('.')
-      .replace(/:/g, '')
-      .split('.')
-      .filter((x) => x)
-      .join('.') + '.ip6.arpa'
-  );
+  return fullAddress.split('').reverse().join('.') + '.ip6.arpa';
 };
 
 export const ipToDnsName = (ip: string) =>

--- a/lib/ips.ts
+++ b/lib/ips.ts
@@ -67,15 +67,30 @@ export const ipv4ToDnsName = (ipv4: string) =>
   ipv4.split('.').reverse().join('.') + '.in-addr.arpa';
 
 export const ipv6ToDnsName = (ipv6: string) => {
+  let normalizedIpv6 = ipv6.toLowerCase();
+  const lastColonIndex = normalizedIpv6.lastIndexOf(':');
+  const lastSegment = normalizedIpv6.slice(lastColonIndex + 1);
+
+  if (lastSegment.includes('.')) {
+    const octets = lastSegment.split('.').map(Number);
+    const embeddedIpv4Segments = [
+      ((octets[0] << 8) | octets[1]).toString(16),
+      ((octets[2] << 8) | octets[3]).toString(16),
+    ];
+    normalizedIpv6 =
+      normalizedIpv6.slice(0, lastColonIndex + 1) +
+      embeddedIpv4Segments.join(':');
+  }
+
   let segments: string[];
-  if (ipv6.includes('::')) {
-    const [head, tail] = ipv6.split('::');
+  if (normalizedIpv6.includes('::')) {
+    const [head, tail] = normalizedIpv6.split('::');
     const headSegments = head ? head.split(':') : [];
     const tailSegments = tail ? tail.split(':') : [];
     const missing = 8 - headSegments.length - tailSegments.length;
     segments = [...headSegments, ...Array(missing).fill('0'), ...tailSegments];
   } else {
-    segments = ipv6.split(':');
+    segments = normalizedIpv6.split(':');
   }
   const fullAddress = segments
     .map((segment) => segment.padStart(4, '0'))


### PR DESCRIPTION
## Summary
- `ipv6ToDnsName` padded every split segment before inserting zeros for the `::` marker, so the empty segment created by `::` became `0000` and the missing-hextet count then added even more zeros on top — producing 36 nibbles instead of 32 for inputs like `2001:db8::1`. `lookupReverse` then queried Cloudflare DNS with a malformed `ip6.arpa` name and reverse lookups silently failed for common compressed IPv6 forms.
- Rewrote the expansion to split around `::` and compute the missing hextet count from the non-empty halves, so the result is always exactly 32 nibbles.
- Added support for IPv4-embedded/mapped IPv6 addresses (e.g. `::ffff:192.0.2.128`, `2001:db8::192.0.2.33`) by converting the trailing dotted-quad into two hextets before expansion.
- Normalized uppercase hex digits to lowercase up front so `2001:DB8::1` produces the same `ip6.arpa` name as `2001:db8::1`.
- Expanded tests to cover `::`, `::1`, trailing `::`, fully expanded addresses, uppercase input, IPv4-mapped and IPv4-embedded forms, uncompressed addresses with short hextets, and added a generic invariant that every valid IPv6 input yields a 32-nibble `ip6.arpa` name with only single hex digits between dots.

## Test plan
- [x] `pnpm vitest run lib/ips.test.ts` — all tests pass
- [x] `tsc --noEmit` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes reverse DNS conversion for IPv6 so `ipv6ToDnsName` always returns a valid 32‑nibble `.ip6.arpa` name, even for compressed inputs. Adds support for IPv4‑mapped/embedded IPv6 and normalizes hex to lowercase.

- **Bug Fixes**
  - Correct `::` expansion by splitting head/tail and padding to 8 segments.
  - Handle embedded IPv4 quads (e.g. `::ffff:192.0.2.128`) and lowercase hex.
  - Zero‑pad hextets and reverse nibbles to emit exactly 32 labels; tests cover `::`, `::1`, trailing `::`, uppercase input, embedded IPv4, uncompressed short hextets, and a 32‑nibble invariant.

<sup>Written for commit 2a22ea2ccc7141937ff0e0d356ca89b4b4134555. Summary will update on new commits. <a href="https://cubic.dev/pr/wotschofsky/domain-digger/pull/77?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->