### PR TITLE
Bump CI setup-node to Node.js 24 ⬆️🌱

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,10 @@ jobs:
         with:
           version: 9
 
-      - name: Setup Node.js 20
+      - name: Setup Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Install Dependencies
@@ -47,10 +47,10 @@ jobs:
         with:
           version: 9
 
-      - name: Setup Node.js 20
+      - name: Setup Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Install Dependencies
@@ -72,10 +72,10 @@ jobs:
         with:
           version: 9
 
-      - name: Setup Node.js 20
+      - name: Setup Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Install Dependencies


### PR DESCRIPTION
## Summary
- `package.json` already declares `"engines.node": "24"`, but `.github/workflows/test.yml` was still installing Node 20 in the formatting, linting, and test jobs.
- Updates all three `actions/setup-node` steps to `node-version: 24` so CI runs against the same Node version the project requires.

No application code, Dockerfiles, `.nvmrc`, or docs needed changes — this PR is purely a GitHub Actions workflow bump.
