### PR TITLE
Add IP filtering to prevent DNS-based SSRF attacks 🛡️⛔

### DIFF
--- a/lib/resolvers/authoritative.ts
+++ b/lib/resolvers/authoritative.ts
@@ -335,69 +335,73 @@ export class AuthoritativeResolver extends DnsResolver {
       return { records, trace: fullTrace };
     }
 
-    // NS records carry the delegation; A records (glue) live in additionals.
     // We must validate referrals before following them: an attacker controlling
     // a delegated zone can otherwise point our recursive query at loopback or
     // RFC1918 addresses and turn this resolver into an SSRF primitive.
-    const nsRedirects = [
-      ...(response.authorities || []),
-      ...(response.additionals || []),
-    ].filter((answer): answer is StringAnswer => answer.type === 'NS');
-
-    const delegatedNsNames = new Set(
-      nsRedirects.map((r) => r.data.toLowerCase()),
-    );
-
-    // Only trust glue A records that match a delegated NS hostname (in-bailiwick)
-    // and resolve to a publicly routable IP address.
-    const aRedirects = [
+    const redirects = [
       ...(response.authorities || []),
       ...(response.additionals || []),
     ].filter(
       (answer): answer is StringAnswer =>
-        answer.type === 'A' &&
-        delegatedNsNames.has(answer.name.toLowerCase()) &&
-        isPublicIp(answer.data),
+        answer.type === 'A' || answer.type === 'NS',
     );
 
-    if (aRedirects.length) {
-      return this.fetchRecords({
-        domain,
-        recordType,
-        nameserver: aRedirects[0].data,
-        trace: [
-          ...trace,
-          `${recordType} ${domain} @ ${usedNameserver} (${protocol}) -> redirect to ${aRedirects.map((r) => r.data).join(', ')}`,
-        ],
-        depth: depth + 1,
-      });
-    }
-
-    if (nsRedirects.length) {
-      const { records: aRecords, trace: subTrace } = await this.fetchRecords({
-        domain: nsRedirects[0].data,
-        recordType: 'A',
-        depth: depth + 1,
-      });
-
-      // The resolved NS address is attacker-controlled (they own the zone and
-      // can set any A record); filter to public IPs before using it.
-      const publicARecords = aRecords.filter((r) => isPublicIp(r.data));
-      if (!publicARecords.length) {
-        throw new Error(`Bad redirects for ${domain}`);
+    if (redirects.length) {
+      // Only trust glue A records that match a delegated NS hostname
+      // (in-bailiwick) and resolve to a publicly routable IP address.
+      const delegatedNsNames = new Set(
+        redirects
+          .filter((r) => r.type === 'NS')
+          .map((r) => r.data.toLowerCase()),
+      );
+      const aRedirects = redirects.filter(
+        (redirect) =>
+          redirect.type === 'A' &&
+          delegatedNsNames.has(redirect.name.toLowerCase()) &&
+          isPublicIp(redirect.data),
+      );
+      if (aRedirects.length) {
+        return this.fetchRecords({
+          domain,
+          recordType,
+          nameserver: aRedirects[0].data,
+          trace: [
+            ...trace,
+            `${recordType} ${domain} @ ${usedNameserver} (${protocol}) -> redirect to ${aRedirects.map((r) => r.data).join(', ')}`,
+          ],
+          depth: depth + 1,
+        });
       }
 
-      return this.fetchRecords({
-        domain,
-        recordType,
-        nameserver: publicARecords[0].data,
-        trace: [
-          ...trace,
-          `${recordType} ${domain} @ ${usedNameserver} (${protocol}) -> redirect to ${nsRedirects.map((r) => r.data).join(', ')}`,
-          ...subTrace,
-        ],
-        depth: depth + 1,
-      });
+      const nsRedirects = redirects.filter((redirect) => redirect.type === 'NS');
+      if (nsRedirects.length) {
+        const { records: aRecords, trace: subTrace } = await this.fetchRecords({
+          domain: nsRedirects[0].data,
+          recordType: 'A',
+          depth: depth + 1,
+        });
+
+        // The resolved NS address is attacker-controlled (they own the zone
+        // and can set any A record); filter to public IPs before using it.
+        const publicARecords = aRecords.filter((r) => isPublicIp(r.data));
+        if (!publicARecords.length) {
+          throw new Error(`Bad redirects for ${domain}`);
+        }
+
+        return this.fetchRecords({
+          domain,
+          recordType,
+          nameserver: publicARecords[0].data,
+          trace: [
+            ...trace,
+            `${recordType} ${domain} @ ${usedNameserver} (${protocol}) -> redirect to ${nsRedirects.map((r) => r.data).join(', ')}`,
+            ...subTrace,
+          ],
+          depth: depth + 1,
+        });
+      }
+
+      throw new Error(`Bad redirects for ${domain}`);
     }
 
     return { records: [], trace };

--- a/lib/resolvers/authoritative.ts
+++ b/lib/resolvers/authoritative.ts
@@ -19,6 +19,7 @@ import {
   type RecordType,
   type ResolverResponse,
 } from './base';
+import { isPublicIp } from './ip-filter';
 
 type DnsResponse = {
   packet: Packet;
@@ -334,57 +335,69 @@ export class AuthoritativeResolver extends DnsResolver {
       return { records, trace: fullTrace };
     }
 
-    // TODO Support IPv6
-    const redirects = [
+    // NS records carry the delegation; A records (glue) live in additionals.
+    // We must validate referrals before following them: an attacker controlling
+    // a delegated zone can otherwise point our recursive query at loopback or
+    // RFC1918 addresses and turn this resolver into an SSRF primitive.
+    const nsRedirects = [
       ...(response.authorities || []),
       ...(response.additionals || []),
-    ].filter((answer) => answer.type === 'A' || answer.type === 'NS');
+    ].filter((answer): answer is StringAnswer => answer.type === 'NS');
 
-    if (redirects.length) {
-      const aRedirects = redirects.filter(
-        (redirect) => redirect.type === 'A',
-      ) as StringAnswer[];
-      if (aRedirects.length) {
-        return this.fetchRecords({
-          domain,
-          recordType,
-          nameserver: aRedirects[0].data,
-          trace: [
-            ...trace,
-            `${recordType} ${domain} @ ${usedNameserver} (${protocol}) -> redirect to ${aRedirects.map((r) => r.data).join(', ')}`,
-          ],
-          depth: depth + 1,
-        });
+    const delegatedNsNames = new Set(
+      nsRedirects.map((r) => r.data.toLowerCase()),
+    );
+
+    // Only trust glue A records that match a delegated NS hostname (in-bailiwick)
+    // and resolve to a publicly routable IP address.
+    const aRedirects = [
+      ...(response.authorities || []),
+      ...(response.additionals || []),
+    ].filter(
+      (answer): answer is StringAnswer =>
+        answer.type === 'A' &&
+        delegatedNsNames.has(answer.name.toLowerCase()) &&
+        isPublicIp(answer.data),
+    );
+
+    if (aRedirects.length) {
+      return this.fetchRecords({
+        domain,
+        recordType,
+        nameserver: aRedirects[0].data,
+        trace: [
+          ...trace,
+          `${recordType} ${domain} @ ${usedNameserver} (${protocol}) -> redirect to ${aRedirects.map((r) => r.data).join(', ')}`,
+        ],
+        depth: depth + 1,
+      });
+    }
+
+    if (nsRedirects.length) {
+      const { records: aRecords, trace: subTrace } = await this.fetchRecords({
+        domain: nsRedirects[0].data,
+        recordType: 'A',
+        depth: depth + 1,
+      });
+
+      // The resolved NS address is attacker-controlled (they own the zone and
+      // can set any A record); filter to public IPs before using it.
+      const publicARecords = aRecords.filter((r) => isPublicIp(r.data));
+      if (!publicARecords.length) {
+        throw new Error(`Bad redirects for ${domain}`);
       }
 
-      const nsRedirects = redirects.filter(
-        (redirect) => redirect.type === 'NS',
-      ) as StringAnswer[];
-      if (nsRedirects.length) {
-        const { records: aRecords, trace: subTrace } = await this.fetchRecords({
-          domain: nsRedirects[0].data,
-          recordType: 'A',
-          depth: depth + 1,
-        });
-
-        if (!aRecords.length) {
-          throw new Error(`Bad redirects for ${domain}`);
-        }
-
-        return this.fetchRecords({
-          domain,
-          recordType,
-          nameserver: aRecords[0].data,
-          trace: [
-            ...trace,
-            `${recordType} ${domain} @ ${usedNameserver} (${protocol}) -> redirect to ${nsRedirects.map((r) => r.data).join(', ')}`,
-            ...subTrace,
-          ],
-          depth: depth + 1,
-        });
-      }
-
-      throw new Error(`Bad redirects for ${domain}`);
+      return this.fetchRecords({
+        domain,
+        recordType,
+        nameserver: publicARecords[0].data,
+        trace: [
+          ...trace,
+          `${recordType} ${domain} @ ${usedNameserver} (${protocol}) -> redirect to ${nsRedirects.map((r) => r.data).join(', ')}`,
+          ...subTrace,
+        ],
+        depth: depth + 1,
+      });
     }
 
     return { records: [], trace };

--- a/lib/resolvers/ip-filter.test.ts
+++ b/lib/resolvers/ip-filter.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+
+import { isPublicIp } from './ip-filter';
+
+describe('isPublicIp', () => {
+  describe('invalid input', () => {
+    it.each([
+      '',
+      'not-an-ip',
+      '256.0.0.1',
+      '1.2.3',
+      '1.2.3.4.5',
+      'gggg::',
+      '::g',
+    ])('returns false for %j', (input) => {
+      expect(isPublicIp(input)).toBe(false);
+    });
+  });
+
+  describe('IPv4 private/reserved ranges', () => {
+    it.each([
+      // Unspecified / "this network"
+      '0.0.0.0',
+      '0.1.2.3',
+      // Private RFC1918
+      '10.0.0.1',
+      '10.255.255.255',
+      '172.16.0.1',
+      '172.31.255.255',
+      '192.168.0.1',
+      '192.168.255.255',
+      // Loopback
+      '127.0.0.1',
+      '127.1.2.3',
+      // Link-local
+      '169.254.0.1',
+      '169.254.169.254',
+      // Carrier-grade NAT
+      '100.64.0.1',
+      '100.127.255.254',
+      // Documentation / TEST-NET
+      '192.0.2.1',
+      '198.51.100.1',
+      '203.0.113.1',
+      // Benchmarking
+      '198.18.0.1',
+      '198.19.255.254',
+      // IETF protocol assignments
+      '192.0.0.1',
+      // Multicast
+      '224.0.0.1',
+      '239.255.255.255',
+      // Reserved / broadcast
+      '240.0.0.1',
+      '255.255.255.255',
+    ])('rejects %s', (ip) => {
+      expect(isPublicIp(ip)).toBe(false);
+    });
+  });
+
+  describe('IPv4 public addresses', () => {
+    it.each([
+      '1.1.1.1',
+      '8.8.8.8',
+      '9.9.9.9',
+      '198.41.0.4', // a.root-servers.net
+      '192.5.6.30', // a.gtld-servers.net
+      '172.15.255.255', // just outside private range
+      '172.32.0.1', // just outside private range
+      '192.167.255.255', // just outside private range
+      '100.63.255.255', // just outside CGN range
+      '100.128.0.0', // just outside CGN range
+      '169.253.255.255', // just outside link-local
+      '169.255.0.0', // just outside link-local
+      '223.255.255.255', // just below multicast
+    ])('accepts %s', (ip) => {
+      expect(isPublicIp(ip)).toBe(true);
+    });
+  });
+
+  describe('IPv6 private/reserved ranges', () => {
+    it.each([
+      // Unspecified
+      '::',
+      // Loopback
+      '::1',
+      // IPv4-mapped private addresses
+      '::ffff:127.0.0.1',
+      '::ffff:10.0.0.1',
+      '::ffff:192.168.1.1',
+      // Unique-local
+      'fc00::1',
+      'fd12:3456:789a::1',
+      // Link-local
+      'fe80::1',
+      'febf:ffff::1',
+      // Multicast
+      'ff00::1',
+      'ff02::1',
+      // Discard prefix
+      '100::1',
+      // Documentation
+      '2001:db8::1',
+      '2001:0db8:1234::',
+      // Well-known NAT64
+      '64:ff9b::1.2.3.4',
+    ])('rejects %s', (ip) => {
+      expect(isPublicIp(ip)).toBe(false);
+    });
+  });
+
+  describe('IPv6 public addresses', () => {
+    it.each([
+      '2001:4860:4860::8888', // Google DNS
+      '2606:4700:4700::1111', // Cloudflare DNS
+      '2620:fe::fe', // Quad9
+      '::ffff:8.8.8.8', // IPv4-mapped public
+      'fbff::1', // just below fc00::/7
+    ])('accepts %s', (ip) => {
+      expect(isPublicIp(ip)).toBe(true);
+    });
+  });
+});

--- a/lib/resolvers/ip-filter.ts
+++ b/lib/resolvers/ip-filter.ts
@@ -1,134 +1,32 @@
-import net from 'node:net';
+import { BlockList, isIP } from 'node:net';
 
-const isPublicIpv4 = (ip: string): boolean => {
-  const parts = ip.split('.');
-  if (parts.length !== 4) return false;
-  const octets = parts.map((p) => Number(p));
-  if (octets.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) {
-    return false;
-  }
-  const [a, b, c] = octets;
+const blocked = new BlockList();
 
-  // 0.0.0.0/8 - "this network"
-  if (a === 0) return false;
-  // 10.0.0.0/8 - private
-  if (a === 10) return false;
-  // 100.64.0.0/10 - shared address space (Carrier-grade NAT)
-  if (a === 100 && b >= 64 && b <= 127) return false;
-  // 127.0.0.0/8 - loopback
-  if (a === 127) return false;
-  // 169.254.0.0/16 - link-local
-  if (a === 169 && b === 254) return false;
-  // 172.16.0.0/12 - private
-  if (a === 172 && b >= 16 && b <= 31) return false;
-  // 192.0.0.0/24 - IETF protocol assignments
-  if (a === 192 && b === 0 && c === 0) return false;
-  // 192.0.2.0/24 - TEST-NET-1 (documentation)
-  if (a === 192 && b === 0 && c === 2) return false;
-  // 192.168.0.0/16 - private
-  if (a === 192 && b === 168) return false;
-  // 198.18.0.0/15 - benchmarking
-  if (a === 198 && (b === 18 || b === 19)) return false;
-  // 198.51.100.0/24 - TEST-NET-2 (documentation)
-  if (a === 198 && b === 51 && c === 100) return false;
-  // 203.0.113.0/24 - TEST-NET-3 (documentation)
-  if (a === 203 && b === 0 && c === 113) return false;
-  // 224.0.0.0/4 - multicast
-  if (a >= 224 && a <= 239) return false;
-  // 240.0.0.0/4 - reserved (including 255.255.255.255 broadcast)
-  if (a >= 240) return false;
+// IPv4 reserved / non-routable ranges
+blocked.addSubnet('0.0.0.0', 8); // "this network"
+blocked.addSubnet('10.0.0.0', 8); // private
+blocked.addSubnet('100.64.0.0', 10); // carrier-grade NAT (RFC 6598)
+blocked.addSubnet('127.0.0.0', 8); // loopback
+blocked.addSubnet('169.254.0.0', 16); // link-local
+blocked.addSubnet('172.16.0.0', 12); // private
+blocked.addSubnet('192.0.0.0', 24); // IETF protocol assignments
+blocked.addSubnet('192.0.2.0', 24); // TEST-NET-1 (documentation)
+blocked.addSubnet('192.168.0.0', 16); // private
+blocked.addSubnet('198.18.0.0', 15); // benchmarking
+blocked.addSubnet('198.51.100.0', 24); // TEST-NET-2 (documentation)
+blocked.addSubnet('203.0.113.0', 24); // TEST-NET-3 (documentation)
+blocked.addSubnet('224.0.0.0', 4); // multicast
+blocked.addSubnet('240.0.0.0', 4); // reserved (incl. 255.255.255.255 broadcast)
 
-  return true;
-};
-
-const expandIpv6 = (ip: string): number[] | null => {
-  if (!net.isIPv6(ip)) return null;
-
-  let normalized = ip.toLowerCase();
-
-  // Strip zone identifier (e.g. fe80::1%eth0)
-  const zoneIdx = normalized.indexOf('%');
-  if (zoneIdx !== -1) {
-    normalized = normalized.slice(0, zoneIdx);
-  }
-
-  // Handle embedded IPv4 (e.g. ::ffff:192.0.2.1)
-  const lastColon = normalized.lastIndexOf(':');
-  const tail = normalized.slice(lastColon + 1);
-  if (tail.includes('.')) {
-    if (!net.isIPv4(tail)) return null;
-    const octets = tail.split('.').map(Number);
-    const seg1 = ((octets[0] << 8) | octets[1]).toString(16);
-    const seg2 = ((octets[2] << 8) | octets[3]).toString(16);
-    normalized = normalized.slice(0, lastColon + 1) + seg1 + ':' + seg2;
-  }
-
-  let segments: string[];
-  if (normalized.includes('::')) {
-    const [head, rest] = normalized.split('::');
-    const headSegs = head ? head.split(':') : [];
-    const tailSegs = rest ? rest.split(':') : [];
-    const missing = 8 - headSegs.length - tailSegs.length;
-    if (missing < 0) return null;
-    segments = [...headSegs, ...Array(missing).fill('0'), ...tailSegs];
-  } else {
-    segments = normalized.split(':');
-  }
-
-  if (segments.length !== 8) return null;
-  const numeric = segments.map((s) => parseInt(s, 16));
-  if (numeric.some((n) => !Number.isInteger(n) || n < 0 || n > 0xffff)) {
-    return null;
-  }
-  return numeric;
-};
-
-const isPublicIpv6 = (ip: string): boolean => {
-  const parts = expandIpv6(ip);
-  if (!parts) return false;
-
-  // ::/128 - unspecified
-  if (parts.every((p) => p === 0)) return false;
-  // ::1/128 - loopback
-  if (parts.slice(0, 7).every((p) => p === 0) && parts[7] === 1) return false;
-  // ::ffff:0:0/96 - IPv4-mapped IPv6 -- defer to IPv4 policy
-  if (parts.slice(0, 5).every((p) => p === 0) && parts[5] === 0xffff) {
-    const embedded = `${(parts[6] >> 8) & 0xff}.${parts[6] & 0xff}.${
-      (parts[7] >> 8) & 0xff
-    }.${parts[7] & 0xff}`;
-    return isPublicIpv4(embedded);
-  }
-  // 64:ff9b::/96 - well-known NAT64 prefix
-  if (
-    parts[0] === 0x0064 &&
-    parts[1] === 0xff9b &&
-    parts[2] === 0 &&
-    parts[3] === 0 &&
-    parts[4] === 0 &&
-    parts[5] === 0
-  ) {
-    return false;
-  }
-  // 100::/64 - discard prefix
-  if (
-    parts[0] === 0x0100 &&
-    parts[1] === 0 &&
-    parts[2] === 0 &&
-    parts[3] === 0
-  ) {
-    return false;
-  }
-  // 2001:db8::/32 - documentation
-  if (parts[0] === 0x2001 && parts[1] === 0x0db8) return false;
-  // fc00::/7 - unique-local
-  if ((parts[0] & 0xfe00) === 0xfc00) return false;
-  // fe80::/10 - link-local
-  if ((parts[0] & 0xffc0) === 0xfe80) return false;
-  // ff00::/8 - multicast
-  if ((parts[0] & 0xff00) === 0xff00) return false;
-
-  return true;
-};
+// IPv6 reserved / non-routable ranges
+blocked.addAddress('::', 'ipv6'); // unspecified
+blocked.addAddress('::1', 'ipv6'); // loopback
+blocked.addSubnet('64:ff9b::', 96, 'ipv6'); // well-known NAT64
+blocked.addSubnet('100::', 64, 'ipv6'); // discard prefix
+blocked.addSubnet('2001:db8::', 32, 'ipv6'); // documentation
+blocked.addSubnet('fc00::', 7, 'ipv6'); // unique-local
+blocked.addSubnet('fe80::', 10, 'ipv6'); // link-local
+blocked.addSubnet('ff00::', 8, 'ipv6'); // multicast
 
 /**
  * Returns true only for IP addresses that are public/routable on the Internet.
@@ -139,8 +37,10 @@ const isPublicIpv6 = (ip: string): boolean => {
  * authoritative resolver to send DNS traffic to internal hosts.
  */
 export const isPublicIp = (ip: string): boolean => {
-  const version = net.isIP(ip);
-  if (version === 4) return isPublicIpv4(ip);
-  if (version === 6) return isPublicIpv6(ip);
-  return false;
+  const version = isIP(ip);
+  if (!version) return false;
+  if (version === 4) return !blocked.check(ip, 'ipv4');
+  // For IPv6, also apply IPv4 policy to catch IPv4-mapped addresses like
+  // ::ffff:10.0.0.1; BlockList.check coerces them to their IPv4 form.
+  return !blocked.check(ip, 'ipv6') && !blocked.check(ip, 'ipv4');
 };

--- a/lib/resolvers/ip-filter.ts
+++ b/lib/resolvers/ip-filter.ts
@@ -1,0 +1,146 @@
+import net from 'node:net';
+
+const isPublicIpv4 = (ip: string): boolean => {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return false;
+  const octets = parts.map((p) => Number(p));
+  if (octets.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) {
+    return false;
+  }
+  const [a, b, c] = octets;
+
+  // 0.0.0.0/8 - "this network"
+  if (a === 0) return false;
+  // 10.0.0.0/8 - private
+  if (a === 10) return false;
+  // 100.64.0.0/10 - shared address space (Carrier-grade NAT)
+  if (a === 100 && b >= 64 && b <= 127) return false;
+  // 127.0.0.0/8 - loopback
+  if (a === 127) return false;
+  // 169.254.0.0/16 - link-local
+  if (a === 169 && b === 254) return false;
+  // 172.16.0.0/12 - private
+  if (a === 172 && b >= 16 && b <= 31) return false;
+  // 192.0.0.0/24 - IETF protocol assignments
+  if (a === 192 && b === 0 && c === 0) return false;
+  // 192.0.2.0/24 - TEST-NET-1 (documentation)
+  if (a === 192 && b === 0 && c === 2) return false;
+  // 192.168.0.0/16 - private
+  if (a === 192 && b === 168) return false;
+  // 198.18.0.0/15 - benchmarking
+  if (a === 198 && (b === 18 || b === 19)) return false;
+  // 198.51.100.0/24 - TEST-NET-2 (documentation)
+  if (a === 198 && b === 51 && c === 100) return false;
+  // 203.0.113.0/24 - TEST-NET-3 (documentation)
+  if (a === 203 && b === 0 && c === 113) return false;
+  // 224.0.0.0/4 - multicast
+  if (a >= 224 && a <= 239) return false;
+  // 240.0.0.0/4 - reserved (including 255.255.255.255 broadcast)
+  if (a >= 240) return false;
+
+  return true;
+};
+
+const expandIpv6 = (ip: string): number[] | null => {
+  if (!net.isIPv6(ip)) return null;
+
+  let normalized = ip.toLowerCase();
+
+  // Strip zone identifier (e.g. fe80::1%eth0)
+  const zoneIdx = normalized.indexOf('%');
+  if (zoneIdx !== -1) {
+    normalized = normalized.slice(0, zoneIdx);
+  }
+
+  // Handle embedded IPv4 (e.g. ::ffff:192.0.2.1)
+  const lastColon = normalized.lastIndexOf(':');
+  const tail = normalized.slice(lastColon + 1);
+  if (tail.includes('.')) {
+    if (!net.isIPv4(tail)) return null;
+    const octets = tail.split('.').map(Number);
+    const seg1 = ((octets[0] << 8) | octets[1]).toString(16);
+    const seg2 = ((octets[2] << 8) | octets[3]).toString(16);
+    normalized = normalized.slice(0, lastColon + 1) + seg1 + ':' + seg2;
+  }
+
+  let segments: string[];
+  if (normalized.includes('::')) {
+    const [head, rest] = normalized.split('::');
+    const headSegs = head ? head.split(':') : [];
+    const tailSegs = rest ? rest.split(':') : [];
+    const missing = 8 - headSegs.length - tailSegs.length;
+    if (missing < 0) return null;
+    segments = [...headSegs, ...Array(missing).fill('0'), ...tailSegs];
+  } else {
+    segments = normalized.split(':');
+  }
+
+  if (segments.length !== 8) return null;
+  const numeric = segments.map((s) => parseInt(s, 16));
+  if (numeric.some((n) => !Number.isInteger(n) || n < 0 || n > 0xffff)) {
+    return null;
+  }
+  return numeric;
+};
+
+const isPublicIpv6 = (ip: string): boolean => {
+  const parts = expandIpv6(ip);
+  if (!parts) return false;
+
+  // ::/128 - unspecified
+  if (parts.every((p) => p === 0)) return false;
+  // ::1/128 - loopback
+  if (parts.slice(0, 7).every((p) => p === 0) && parts[7] === 1) return false;
+  // ::ffff:0:0/96 - IPv4-mapped IPv6 -- defer to IPv4 policy
+  if (parts.slice(0, 5).every((p) => p === 0) && parts[5] === 0xffff) {
+    const embedded = `${(parts[6] >> 8) & 0xff}.${parts[6] & 0xff}.${
+      (parts[7] >> 8) & 0xff
+    }.${parts[7] & 0xff}`;
+    return isPublicIpv4(embedded);
+  }
+  // 64:ff9b::/96 - well-known NAT64 prefix
+  if (
+    parts[0] === 0x0064 &&
+    parts[1] === 0xff9b &&
+    parts[2] === 0 &&
+    parts[3] === 0 &&
+    parts[4] === 0 &&
+    parts[5] === 0
+  ) {
+    return false;
+  }
+  // 100::/64 - discard prefix
+  if (
+    parts[0] === 0x0100 &&
+    parts[1] === 0 &&
+    parts[2] === 0 &&
+    parts[3] === 0
+  ) {
+    return false;
+  }
+  // 2001:db8::/32 - documentation
+  if (parts[0] === 0x2001 && parts[1] === 0x0db8) return false;
+  // fc00::/7 - unique-local
+  if ((parts[0] & 0xfe00) === 0xfc00) return false;
+  // fe80::/10 - link-local
+  if ((parts[0] & 0xffc0) === 0xfe80) return false;
+  // ff00::/8 - multicast
+  if ((parts[0] & 0xff00) === 0xff00) return false;
+
+  return true;
+};
+
+/**
+ * Returns true only for IP addresses that are public/routable on the Internet.
+ * Rejects loopback, RFC1918 private, link-local, multicast, documentation,
+ * unspecified, and other reserved ranges in both IPv4 and IPv6.
+ *
+ * Used to prevent attacker-controlled DNS referrals from forcing the
+ * authoritative resolver to send DNS traffic to internal hosts.
+ */
+export const isPublicIp = (ip: string): boolean => {
+  const version = net.isIP(ip);
+  if (version === 4) return isPublicIpv4(ip);
+  if (version === 6) return isPublicIpv6(ip);
+  return false;
+};


### PR DESCRIPTION
## Summary
This PR adds IP address validation to the authoritative DNS resolver to prevent attackers from exploiting DNS referrals to force queries to internal or non-routable addresses, which could turn the resolver into an SSRF primitive.

## Key Changes
- **New `ip-filter` module** (`lib/resolvers/ip-filter.ts`):
  - Implements `isPublicIp()` function that validates whether an IP address is publicly routable on the Internet
  - Rejects all private ranges (RFC1918), loopback, link-local, multicast, documentation, and reserved address ranges for both IPv4 and IPv6
  - Includes comprehensive IPv6 support with proper expansion of compressed notation and embedded IPv4 addresses
  - Comprehensive test coverage for edge cases and boundary conditions

- **Updated `AuthoritativeResolver`** (`lib/resolvers/authoritative.ts`):
  - Validates glue A records (in-bailiwick) before following DNS referrals
  - Filters resolved NS addresses to only accept publicly routable IPs
  - Prevents following delegations to private/reserved address ranges that could be exploited for SSRF attacks
  - Improved logic to distinguish between in-bailiwick glue records and out-of-bailiwick NS records

## Implementation Details
- IPv4 validation checks all RFC-defined private and reserved ranges including RFC1918 (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16), loopback, link-local, CGN (100.64.0.0/10), and multicast ranges
- IPv6 validation handles compressed notation (`::`), zone identifiers, and IPv4-mapped addresses, checking against equivalent reserved ranges
- Glue record validation ensures A records only match delegated NS hostnames (in-bailiwick constraint) and resolve to public IPs
- NS record resolution also filters results to public IPs before following the delegation

https://claude.ai/code/session_01NL42rioXof236e7GbwLQ6L

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds IP filtering to the authoritative DNS resolver to block DNS-referral SSRF. We now only follow referrals/glue that resolve to public IPs and match delegated NS hosts, with full IPv4/IPv6 support.

- Bug Fixes
  - Added `isPublicIp` using `node:net` `BlockList` to reject private, loopback, link-local, CGN, multicast, documentation, unspecified, and reserved ranges; supports IPv6 (compressed and IPv4-mapped) and input validation.
  - Updated `AuthoritativeResolver` to trust only in-bailiwick glue A records that are public and to use NS-resolved A records only if public; filters non-public IPs and errors when no public target exists.
  - Added tests for IPv4/IPv6 edge cases and boundaries, including IPv4-mapped, NAT64, discard, and documentation ranges.

<sup>Written for commit 46c5c0f65b4c813eeb96f0d9db3fb1a0c1257e04. Summary will update on new commits. <a href="https://cubic.dev/pr/wotschofsky/domain-digger/pull/81?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

