### PR TITLE
Keep current results tab when searching a new domain 🗂️🔍

### DIFF
--- a/app/_components/search-form.tsx
+++ b/app/_components/search-form.tsx
@@ -2,7 +2,12 @@
 
 import { useDebounce, useMeasure } from '@uidotdev/usehooks';
 import { NetworkIcon, SearchIcon } from 'lucide-react';
-import { useParams, usePathname, useRouter } from 'next/navigation';
+import {
+  useParams,
+  usePathname,
+  useRouter,
+  useSelectedLayoutSegment,
+} from 'next/navigation';
 import {
   type ChangeEventHandler,
   type FC,
@@ -92,6 +97,7 @@ export const SearchForm: FC<SearchFormProps> = (props) => {
 
   const router = useRouter();
   const pathname = usePathname();
+  const selectedSegment = useSelectedLayoutSegment();
 
   const { domain: initialValue } = useParams<{ domain: string }>();
   const [domain, setDomain] = useState(initialValue ?? '');
@@ -123,9 +129,17 @@ export const SearchForm: FC<SearchFormProps> = (props) => {
   const redirectUser = (domain: string) => {
     setState(FormStates.Submitting);
 
+    // Keep the current tab when searching from a results page. Route groups
+    // (e.g. the DNS tab's "(dns)") map to no path segment.
+    const subpage =
+      props.subpage ??
+      (selectedSegment && !selectedSegment.startsWith('(')
+        ? selectedSegment
+        : undefined);
+
     let target = `/lookup/${domain}`;
-    if (props.subpage) {
-      target += `/${props.subpage}`;
+    if (subpage) {
+      target += `/${subpage}`;
     }
 
     if (pathname === target) {


### PR DESCRIPTION
## What

When you're on a results page (e.g. `/lookup/example.com/whois`) and search for a different domain from the header, you now stay on the same tab (`/lookup/other.com/whois`) instead of being dropped back to the DNS tab.

## How

`SearchForm` now reads the active tab via `useSelectedLayoutSegment()` — the same hook `results-tabs.tsx` already uses — and appends it to the redirect target. Route group `(dns)` and `null` (landing / not-found pages) fall through to no subpage; landing pages continue to pass an explicit `subpage` prop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the current results tab when searching a new domain from the header. Users stay on the active tab (e.g., WHOIS) instead of being sent back to DNS.

- **Bug Fixes**
  - `SearchForm` now reads the active tab with `useSelectedLayoutSegment()` and appends it to `/lookup/:domain`.
  - Ignores route groups like `(dns)` and `null` segments, so no bogus path segments are added.
  - Keeps support for an explicit `subpage` prop on landing pages; falls back to base results when no segment is present.

<sup>Written for commit 7dd9d158417efc614bdc6e23a3e55ebcc0c75a0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wotschofsky/domain-digger/pull/87?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

