### PR TITLE
Fix React render warnings: keyless fragments and div-in-p hydration 🧩👻

### DIFF
--- a/app/lookup/[domain]/(dns)/_components/record-subvalues.tsx
+++ b/app/lookup/[domain]/(dns)/_components/record-subvalues.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import { type FC, Fragment } from 'react';
 
 import type { RecordContextEntry } from '@/lib/record-context';
 
@@ -9,7 +9,7 @@ type RecordSubvaluesProps = {
 export const RecordSubvalues: FC<RecordSubvaluesProps> = ({ subvalues }) => (
   <span className="mt-1 block text-xs break-words text-zinc-500 dark:text-zinc-400">
     {subvalues.map((s, i) => (
-      <>
+      <Fragment key={i}>
         {i > 0 && ' / '}
         {s.url ? (
           <a
@@ -23,7 +23,7 @@ export const RecordSubvalues: FC<RecordSubvaluesProps> = ({ subvalues }) => (
         ) : (
           s.description
         )}
-      </>
+      </Fragment>
     ))}
   </span>
 );

--- a/app/lookup/[domain]/(dns)/loading.tsx
+++ b/app/lookup/[domain]/(dns)/loading.tsx
@@ -1,15 +1,14 @@
-/* eslint-disable react/jsx-key */
 import { type FC, Fragment } from 'react';
 
 import { Skeleton } from '@/components/ui/skeleton';
 
 const DomainError: FC = () => (
   <div className="mt-12">
-    {Array.from({ length: 3 }).map(() => (
-      <Fragment>
+    {Array.from({ length: 3 }).map((_, i) => (
+      <Fragment key={i}>
         <Skeleton className="mt-8 mb-4 h-7 w-16 rounded-sm" />
-        {Array.from({ length: 3 }).map(() => (
-          <Skeleton className="my-3 h-5 w-full rounded-sm" />
+        {Array.from({ length: 3 }).map((_, j) => (
+          <Skeleton key={j} className="my-3 h-5 w-full rounded-sm" />
         ))}
       </Fragment>
     ))}

--- a/app/lookup/[domain]/_components/star-reminder.tsx
+++ b/app/lookup/[domain]/_components/star-reminder.tsx
@@ -114,7 +114,8 @@ export const StarReminder: FC = () => {
           <AlertDialogTitle className="text-center text-lg font-bold">
             Enjoying Domain Digger?
           </AlertDialogTitle>
-          <AlertDialogDescription>
+          {/* asChild: the default <p> cannot contain the div/p children below */}
+          <AlertDialogDescription asChild>
             <div className="space-y-4">
               <div className="flex justify-center">
                 {data.recentStargazers.map((user, index) => (

--- a/app/lookup/[domain]/certs/_components/table.tsx
+++ b/app/lookup/[domain]/certs/_components/table.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { FC } from 'react';
+import { type FC, Fragment } from 'react';
 
 import { SortableTable } from '@/components/sortable-table';
 import type { CertsData } from '@/lib/certs';
@@ -46,14 +46,14 @@ export const CertsTable: FC<CertsTableProps> = ({ certs }) => (
         label: 'Matching Identities',
         render: (value) =>
           value.split(/\n/g).map((value, index) => (
-            <>
+            <Fragment key={index}>
               {index !== 0 && <br />}
               {isValidDomain(value) ? (
                 <DomainLink domain={value} />
               ) : (
                 <span>{value}</span>
               )}
-            </>
+            </Fragment>
           )),
       },
       {


### PR DESCRIPTION
General cleanup of React warnings noticed in the dev server logs (unrelated to the DNSSEC branch, so split out):

- **Missing `key` warnings**: `record-subvalues.tsx`, the DNS `loading.tsx` skeleton, and the certs table all mapped over keyless shorthand fragments. Now `<Fragment key={…}>`; the loading skeleton's `eslint-disable react/jsx-key` is gone too.
- **Hydration errors**: `star-reminder.tsx` nested `<div>`/`<p>` inside `AlertDialogDescription`, which renders a `<p>`. Using `asChild` renders it as the div directly while keeping the `aria-describedby` wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes React render warnings by adding keys to mapped fragments and resolving a div-in-p hydration issue in the star reminder dialog. Cleans up dev logs and ensures consistent hydration.

- **Bug Fixes**
  - Added key props to mapped fragments in record-subvalues, DNS loading skeleton (also removed the eslint-disable), and the certs table by switching to Fragment with keys and keying inner Skeleton items.
  - Fixed hydration error in star-reminder by using asChild on AlertDialogDescription so it renders a div and keeps aria-describedby.

<sup>Written for commit 4728c10a15d4baf806d44cea1dcdfa94e75c4294. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wotschofsky/domain-digger/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

