### PR TITLE
Centralize lookup feature config and fix tab shortcut hint 📍🗺️

### DIFF
--- a/app/_components/footer.tsx
+++ b/app/_components/footer.tsx
@@ -5,6 +5,7 @@ import { FaGithub, FaHeart } from 'react-icons/fa';
 import { Button } from '@/components/ui/button';
 
 import PoweredByVercel from '@/assets/powered-by-vercel.svg';
+import { LOOKUP_FEATURES } from '@/lib/lookup-features';
 import { cn } from '@/lib/utils';
 
 import { Logo } from './logo';
@@ -50,11 +51,11 @@ export const Footer: FC = () => (
         <div className="flex flex-col gap-2">
           <h2 className="font-semibold">Free Tools</h2>
           <div className="flex flex-col gap-1 text-sm underline decoration-dotted underline-offset-4 lg:flex-row lg:gap-4">
-            <Link href="/">DNS Lookup</Link>
-            <Link href="/map">Global DNS Lookup</Link>
-            <Link href="/whois">WHOIS Lookup</Link>
-            <Link href="/certs">Certificate Logs</Link>
-            <Link href="/subdomains">Subdomains Finder</Link>
+            {LOOKUP_FEATURES.map((feature) => (
+              <Link key={feature.id} href={feature.landingPath}>
+                {feature.footerLabel}
+              </Link>
+            ))}
           </div>
         </div>
 

--- a/app/lookup/[domain]/_components/results-tabs.tsx
+++ b/app/lookup/[domain]/_components/results-tabs.tsx
@@ -8,6 +8,7 @@ import type { FC } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 
 import { ClientOnly } from '@/components/client-only';
+import { LOOKUP_FEATURES } from '@/lib/lookup-features';
 import { cn, isAppleDevice } from '@/lib/utils';
 
 type SingleTabProps = {
@@ -39,13 +40,7 @@ const SingleTab: FC<SingleTabProps> = ({ label, href, selected }) => (
   </li>
 );
 
-const TABS = [
-  { label: 'DNS', segment: '(dns)', path: '' },
-  { label: 'DNS Map', segment: 'map', path: '/map' },
-  { label: 'Whois', segment: 'whois', path: '/whois' },
-  { label: 'Certs', segment: 'certs', path: '/certs' },
-  { label: 'Subdomains', segment: 'subdomains', path: '/subdomains' },
-];
+const TABS = LOOKUP_FEATURES;
 
 type ResultsTabsProps = {
   domain: string;
@@ -83,10 +78,11 @@ export const ResultsTabs: FC<ResultsTabsProps> = ({ domain }) => {
         <kbd className="pointer-events-none absolute top-1/2 right-3 hidden h-5 -translate-y-1/2 items-center gap-1 rounded border border-zinc-200 bg-white px-1.5 font-mono text-[10px] font-medium opacity-100 select-none sm:flex dark:border-zinc-700 dark:bg-zinc-800">
           {isAppleDevice() ? (
             <>
-              <OptionIcon className="inline-block size-2" strokeWidth={3} /> 1-5
+              <OptionIcon className="inline-block size-2" strokeWidth={3} /> 1-
+              {TABS.length}
             </>
           ) : (
-            'ctrl+1-5'
+            `alt+1-${TABS.length}`
           )}
         </kbd>
       </ClientOnly>

--- a/app/lookup/[domain]/_components/results-tabs.tsx
+++ b/app/lookup/[domain]/_components/results-tabs.tsx
@@ -40,8 +40,6 @@ const SingleTab: FC<SingleTabProps> = ({ label, href, selected }) => (
   </li>
 );
 
-const TABS = LOOKUP_FEATURES;
-
 type ResultsTabsProps = {
   domain: string;
 };
@@ -51,10 +49,10 @@ export const ResultsTabs: FC<ResultsTabsProps> = ({ domain }) => {
   const selectedSegment = useSelectedLayoutSegment();
 
   useHotkeys(
-    TABS.map((_, index) => `alt+${index + 1}`).join(','),
+    LOOKUP_FEATURES.map((_, index) => `alt+${index + 1}`).join(','),
     (_, hotkeysEvent) => {
       const shortcutNumber = Number(hotkeysEvent.keys?.[0]);
-      const tab = TABS[shortcutNumber - 1];
+      const tab = LOOKUP_FEATURES[shortcutNumber - 1];
 
       if (tab) router.push(`/lookup/${domain}${tab.path}`);
     },
@@ -64,7 +62,7 @@ export const ResultsTabs: FC<ResultsTabsProps> = ({ domain }) => {
   return (
     <div className="group relative overflow-x-auto overflow-y-hidden rounded-xl text-center text-sm font-medium shadow-[0px_0px_0px_1px_rgba(9,9,11,0.07),0px_2px_2px_0px_rgba(9,9,11,0.05)] dark:shadow-[0px_0px_0px_1px_rgba(255,255,255,0.1)]">
       <ul className="-mb-px flex">
-        {TABS.map((tab) => (
+        {LOOKUP_FEATURES.map((tab) => (
           <SingleTab
             key={tab.segment}
             label={tab.label}
@@ -79,10 +77,10 @@ export const ResultsTabs: FC<ResultsTabsProps> = ({ domain }) => {
           {isAppleDevice() ? (
             <>
               <OptionIcon className="inline-block size-2" strokeWidth={3} /> 1-
-              {TABS.length}
+              {LOOKUP_FEATURES.length}
             </>
           ) : (
-            `alt+1-${TABS.length}`
+            `alt+1-${LOOKUP_FEATURES.length}`
           )}
         </kbd>
       </ClientOnly>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,11 +3,12 @@ import { parse as parseTldts } from 'tldts';
 
 import { env } from '@/env';
 import { EXAMPLE_DOMAINS } from '@/lib/data';
+import { LOOKUP_FEATURES } from '@/lib/lookup-features';
 import { getTopDomains } from '@/lib/search';
 import { deduplicate } from '@/lib/utils';
 
-const LANDING_PAGES = ['', '/certs', '/map', '/subdomains', '/whois'];
-const RESULTS_SUBPATHS = ['', '/certs', '/map', '/subdomains', '/whois'];
+const LANDING_PAGES = LOOKUP_FEATURES.map((feature) => feature.landingPath);
+const RESULTS_SUBPATHS = LOOKUP_FEATURES.map((feature) => feature.path);
 
 const getProgrammaticPaths = async () => {
   const topDomains = await getTopDomains(1000);

--- a/lib/lookup-features.ts
+++ b/lib/lookup-features.ts
@@ -1,0 +1,49 @@
+export const LOOKUP_FEATURES = [
+  {
+    id: 'dns',
+    label: 'DNS',
+    segment: '(dns)',
+    path: '',
+    landingPath: '/',
+    footerLabel: 'DNS Lookup',
+    lookupType: 'dns',
+  },
+  {
+    id: 'map',
+    label: 'DNS Map',
+    segment: 'map',
+    path: '/map',
+    landingPath: '/map',
+    footerLabel: 'Global DNS Lookup',
+    lookupType: 'dns',
+  },
+  {
+    id: 'whois',
+    label: 'Whois',
+    segment: 'whois',
+    path: '/whois',
+    landingPath: '/whois',
+    footerLabel: 'WHOIS Lookup',
+    lookupType: 'whois',
+  },
+  {
+    id: 'certs',
+    label: 'Certs',
+    segment: 'certs',
+    path: '/certs',
+    landingPath: '/certs',
+    footerLabel: 'Certificate Logs',
+    lookupType: 'certs',
+  },
+  {
+    id: 'subdomains',
+    label: 'Subdomains',
+    segment: 'subdomains',
+    path: '/subdomains',
+    landingPath: '/subdomains',
+    footerLabel: 'Subdomains Finder',
+    lookupType: 'subdomains',
+  },
+] as const;
+
+export type LookupType = (typeof LOOKUP_FEATURES)[number]['lookupType'];

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -5,9 +5,8 @@ import { after } from 'next/server';
 import { env } from '@/env';
 import { getVisitorIp, isUserBot } from '@/lib/api';
 import { bigquery } from '@/lib/bigquery';
+import type { LookupType } from '@/lib/lookup-features';
 import { getBaseDomain } from '@/lib/utils';
-
-export type LookupType = 'dns' | 'whois' | 'subdomains' | 'certs';
 
 type LookupLogPayload = {
   domain: string;


### PR DESCRIPTION
## Summary
- Extracts the lookup tab/footer/sitemap refactor from #85 into a standalone PR so the DNSSEC feature can focus on validation logic and UI.
- Adds `lib/lookup-features.ts` as the single source of truth for lookup tool metadata (tabs, footer links, sitemap paths, analytics lookup types).
- Fixes the non-Apple keyboard shortcut hint on result tabs (`ctrl+1-5` → `alt+1-N`) to match the actual `alt+N` bindings and scales the hint with the tab count.

## Test plan
- [x] `pnpm test run` passes
- [ ] Verify result tab hotkeys (alt+1 through alt+5) still navigate correctly
- [ ] Confirm footer links and sitemap generation include all existing tools (no DNSSEC entry yet)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes lookup feature config in `lib/lookup-features.ts` so tabs, hotkeys, footer links, sitemap paths, and logging types come from one source. Also fixes the non-Apple tab shortcut hint to show `alt+1-N`.

- **Refactors**
  - Added `lib/lookup-features.ts` as the single source of truth for lookup tools.
  - Footer links, result tabs + hotkeys, sitemap paths, and analytics logging now derive from `LOOKUP_FEATURES`; `LookupType` exported here and removed from `lib/search.ts`.

- **Bug Fixes**
  - Corrected non-Apple shortcut hint from `ctrl+1-5` to `alt+1-N` (dynamic with tab count).

<sup>Written for commit ed6a5f1011920f0058034e88d2558cb8f04941a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wotschofsky/domain-digger/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

