### PR TITLE
Harden star reminder against broken localStorage 🌟🛡️

### DIFF
--- a/app/lookup/[domain]/_components/star-reminder.tsx
+++ b/app/lookup/[domain]/_components/star-reminder.tsx
@@ -50,8 +50,13 @@ const useSafeLocalStorage = <T,>(key: string, initialValue: T) => {
     const handleStorage = (event: StorageEvent) => {
       try {
         // Accessing window.localStorage can itself throw when storage is
-        // denied, so the guard stays inside the try
-        if (event.key !== key || event.storageArea !== window.localStorage) {
+        // denied, so the guard stays inside the try. A null key means
+        // localStorage.clear() was called in another tab, which also
+        // affects this entry (newValue is null there too).
+        if (
+          (event.key !== null && event.key !== key) ||
+          event.storageArea !== window.localStorage
+        ) {
           return;
         }
 

--- a/app/lookup/[domain]/_components/star-reminder.tsx
+++ b/app/lookup/[domain]/_components/star-reminder.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useLocalStorage } from '@uidotdev/usehooks';
 import ms from 'ms';
 import { type FC, useEffect, useState } from 'react';
 import { FaGithub } from 'react-icons/fa';
@@ -24,6 +23,31 @@ const INITIAL_DELAY = ms('2m');
 const TIMEOUT_PERIOD = ms('7d');
 const SKIP_BUTTON_DELAY = ms('5s');
 
+// Unlike @uidotdev/usehooks' useLocalStorage, this survives blocked storage
+// access (throws SecurityError) and corrupted values (JSON.parse throws),
+// both of which crashed the page during render (#92)
+const useSafeLocalStorage = <T,>(key: string, initialValue: T) => {
+  const [value, setValue] = useState<T>(() => {
+    try {
+      const raw = window.localStorage.getItem(key);
+      return raw === null ? initialValue : JSON.parse(raw);
+    } catch {
+      return initialValue;
+    }
+  });
+
+  const set = (next: T) => {
+    setValue(next);
+    try {
+      window.localStorage.setItem(key, JSON.stringify(next));
+    } catch {
+      // Storage unavailable; state still updates for the current page view
+    }
+  };
+
+  return [value, set] as const;
+};
+
 export const StarReminder: FC = () => {
   const { reportEvent } = useAnalytics();
   const [_, setForceUpdate] = useState(0);
@@ -34,11 +58,11 @@ export const StarReminder: FC = () => {
 
   const { data } = useStargazersSummary();
 
-  const [isStarred, setIsStarred] = useLocalStorage(
+  const [isStarred, setIsStarred] = useSafeLocalStorage(
     'star-reminder.starred',
     false,
   );
-  const [lastDismissed, setLastDismissed] = useLocalStorage(
+  const [lastDismissed, setLastDismissed] = useSafeLocalStorage(
     'star-reminder.last-dismissed',
     Date.now() - TIMEOUT_PERIOD + INITIAL_DELAY,
   );

--- a/app/lookup/[domain]/_components/star-reminder.tsx
+++ b/app/lookup/[domain]/_components/star-reminder.tsx
@@ -25,23 +25,22 @@ const SKIP_BUTTON_DELAY = ms('5s');
 
 // Unlike @uidotdev/usehooks' useLocalStorage, this survives blocked storage
 // access (throws SecurityError) and corrupted values (JSON.parse throws),
-// both of which crashed the page during render (#92)
-const useSafeLocalStorage = <T,>(key: string, initialValue: T) => {
+// both of which crashed the page during render (#92). The initial value is a
+// factory so time-derived fallbacks (the reminder delay anchor) are computed
+// fresh whenever they are needed, not captured at render time.
+const useSafeLocalStorage = <T,>(key: string, getInitialValue: () => T) => {
   const [value, setValue] = useState<T>(() => {
     try {
       const raw = window.localStorage.getItem(key);
-      return raw === null ? initialValue : JSON.parse(raw);
+      return raw === null ? getInitialValue() : JSON.parse(raw);
     } catch {
-      return initialValue;
+      return getInitialValue();
     }
   });
 
-  // Latest-ref so the storage handlers below use the freshest initial value;
-  // lastDismissed's initial value is time-derived and recomputed every render
-  const initialValueRef = useRef(initialValue);
-  useEffect(() => {
-    initialValueRef.current = initialValue;
-  });
+  // The factory only closes over module constants, so the mount-time one
+  // stays correct for the storage handlers below
+  const getInitialValueRef = useRef(getInitialValue);
 
   // Match the replaced hook: persist the initial value so time-based state
   // (the reminder delay anchor) survives reloads, and follow changes made in
@@ -62,7 +61,7 @@ const useSafeLocalStorage = <T,>(key: string, initialValue: T) => {
 
         setValue(
           event.newValue === null
-            ? initialValueRef.current
+            ? getInitialValueRef.current()
             : JSON.parse(event.newValue),
         );
       } catch {
@@ -87,7 +86,7 @@ const useSafeLocalStorage = <T,>(key: string, initialValue: T) => {
       if (parsed === null) {
         window.localStorage.setItem(
           key,
-          JSON.stringify(initialValueRef.current),
+          JSON.stringify(getInitialValueRef.current()),
         );
       } else {
         // Re-sync in case another tab wrote after the initializer ran
@@ -124,11 +123,11 @@ export const StarReminder: FC = () => {
 
   const [isStarred, setIsStarred] = useSafeLocalStorage(
     'star-reminder.starred',
-    false,
+    () => false,
   );
   const [lastDismissed, setLastDismissed] = useSafeLocalStorage(
     'star-reminder.last-dismissed',
-    Date.now() - TIMEOUT_PERIOD + INITIAL_DELAY,
+    () => Date.now() - TIMEOUT_PERIOD + INITIAL_DELAY,
   );
 
   const timeUntilVisible = TIMEOUT_PERIOD - (Date.now() - lastDismissed);

--- a/app/lookup/[domain]/_components/star-reminder.tsx
+++ b/app/lookup/[domain]/_components/star-reminder.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import ms from 'ms';
-import { type FC, useEffect, useState } from 'react';
+import { type FC, useEffect, useRef, useState } from 'react';
 import { FaGithub } from 'react-icons/fa';
 
 import {
@@ -35,6 +35,42 @@ const useSafeLocalStorage = <T,>(key: string, initialValue: T) => {
       return initialValue;
     }
   });
+
+  const initialValueRef = useRef(initialValue);
+
+  // Match the replaced hook: persist the initial value so time-based state
+  // (the reminder delay anchor) survives reloads, and follow changes made in
+  // other tabs
+  useEffect(() => {
+    try {
+      if (window.localStorage.getItem(key) === null) {
+        window.localStorage.setItem(
+          key,
+          JSON.stringify(initialValueRef.current),
+        );
+      }
+    } catch {
+      // Storage unavailable; keep in-memory state only
+    }
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== key || event.storageArea !== window.localStorage) {
+        return;
+      }
+
+      try {
+        setValue(
+          event.newValue === null
+            ? initialValueRef.current
+            : JSON.parse(event.newValue),
+        );
+      } catch {
+        // Ignore corrupted values written by other tabs
+      }
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, [key]);
 
   const set = (next: T) => {
     setValue(next);

--- a/app/lookup/[domain]/_components/star-reminder.tsx
+++ b/app/lookup/[domain]/_components/star-reminder.tsx
@@ -48,11 +48,13 @@ const useSafeLocalStorage = <T,>(key: string, initialValue: T) => {
   // other tabs
   useEffect(() => {
     const handleStorage = (event: StorageEvent) => {
-      if (event.key !== key || event.storageArea !== window.localStorage) {
-        return;
-      }
-
       try {
+        // Accessing window.localStorage can itself throw when storage is
+        // denied, so the guard stays inside the try
+        if (event.key !== key || event.storageArea !== window.localStorage) {
+          return;
+        }
+
         setValue(
           event.newValue === null
             ? initialValueRef.current

--- a/app/lookup/[domain]/_components/star-reminder.tsx
+++ b/app/lookup/[domain]/_components/star-reminder.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import ms from 'ms';
-import { type FC, useEffect, useRef, useState } from 'react';
+import { type FC, useEffect, useState } from 'react';
 import { FaGithub } from 'react-icons/fa';
 
 import {
@@ -17,95 +17,12 @@ import {
 
 import { useStargazersSummary } from '@/app/api/stargazers-summary/hook';
 import { useAnalytics } from '@/lib/analytics';
+import { useSafeLocalStorage } from '@/lib/use-safe-local-storage';
 import { cn } from '@/lib/utils';
 
 const INITIAL_DELAY = ms('2m');
 const TIMEOUT_PERIOD = ms('7d');
 const SKIP_BUTTON_DELAY = ms('5s');
-
-// Unlike @uidotdev/usehooks' useLocalStorage, this survives blocked storage
-// access (throws SecurityError) and corrupted values (JSON.parse throws),
-// both of which crashed the page during render (#92). The initial value is a
-// factory so time-derived fallbacks (the reminder delay anchor) are computed
-// fresh whenever they are needed, not captured at render time.
-const useSafeLocalStorage = <T,>(key: string, getInitialValue: () => T) => {
-  const [value, setValue] = useState<T>(() => {
-    try {
-      const raw = window.localStorage.getItem(key);
-      return raw === null ? getInitialValue() : JSON.parse(raw);
-    } catch {
-      return getInitialValue();
-    }
-  });
-
-  // The factory only closes over module constants, so the mount-time one
-  // stays correct for the storage handlers below
-  const getInitialValueRef = useRef(getInitialValue);
-
-  // Match the replaced hook: persist the initial value so time-based state
-  // (the reminder delay anchor) survives reloads, and follow changes made in
-  // other tabs
-  useEffect(() => {
-    // Storage itself is the authority; events only signal that it changed.
-    // Reading it fresh (instead of trusting event.newValue) keeps
-    // concurrently-writing tabs convergent, and a missing or corrupt entry
-    // is repaired with a fresh fallback so state and storage always hold
-    // the same value — a deleted entry is never resurrected.
-    const syncFromStorage = () => {
-      try {
-        const raw = window.localStorage.getItem(key);
-        if (raw !== null) {
-          try {
-            setValue(JSON.parse(raw));
-            return;
-          } catch {
-            // Corrupted entry (the #92 scenario); repair below
-          }
-        }
-        const fallback = getInitialValueRef.current();
-        setValue(fallback);
-        window.localStorage.setItem(key, JSON.stringify(fallback));
-      } catch {
-        // Storage unavailable; keep in-memory state only
-      }
-    };
-
-    const handleStorage = (event: StorageEvent) => {
-      try {
-        // Accessing window.localStorage can itself throw when storage is
-        // denied, so the guard stays inside a try. A null key means
-        // localStorage.clear() was called in another tab, which also
-        // affects this entry.
-        if (
-          (event.key !== null && event.key !== key) ||
-          event.storageArea !== window.localStorage
-        ) {
-          return;
-        }
-      } catch {
-        return;
-      }
-      syncFromStorage();
-    };
-    // Subscribe before the initial sync so a write from another tab between
-    // the useState initializer and this effect cannot be missed
-    window.addEventListener('storage', handleStorage);
-    syncFromStorage();
-
-    return () => window.removeEventListener('storage', handleStorage);
-  }, [key]);
-
-  const set = (next: T) => {
-    setValue(next);
-    try {
-      window.localStorage.setItem(key, JSON.stringify(next));
-    } catch {
-      // Storage unavailable; state still updates for the current page view
-    }
-  };
-
-  return [value, set] as const;
-};
 
 export const StarReminder: FC = () => {
   const { reportEvent } = useAnalytics();

--- a/app/lookup/[domain]/_components/star-reminder.tsx
+++ b/app/lookup/[domain]/_components/star-reminder.tsx
@@ -46,63 +46,51 @@ const useSafeLocalStorage = <T,>(key: string, getInitialValue: () => T) => {
   // (the reminder delay anchor) survives reloads, and follow changes made in
   // other tabs
   useEffect(() => {
+    // Storage itself is the authority; events only signal that it changed.
+    // Reading it fresh (instead of trusting event.newValue) keeps
+    // concurrently-writing tabs convergent, and a missing or corrupt entry
+    // is repaired with a fresh fallback so state and storage always hold
+    // the same value — a deleted entry is never resurrected.
+    const syncFromStorage = () => {
+      try {
+        const raw = window.localStorage.getItem(key);
+        if (raw !== null) {
+          try {
+            setValue(JSON.parse(raw));
+            return;
+          } catch {
+            // Corrupted entry (the #92 scenario); repair below
+          }
+        }
+        const fallback = getInitialValueRef.current();
+        setValue(fallback);
+        window.localStorage.setItem(key, JSON.stringify(fallback));
+      } catch {
+        // Storage unavailable; keep in-memory state only
+      }
+    };
+
     const handleStorage = (event: StorageEvent) => {
       try {
         // Accessing window.localStorage can itself throw when storage is
-        // denied, so the guard stays inside the try. A null key means
+        // denied, so the guard stays inside a try. A null key means
         // localStorage.clear() was called in another tab, which also
-        // affects this entry (newValue is null there too).
+        // affects this entry.
         if (
           (event.key !== null && event.key !== key) ||
           event.storageArea !== window.localStorage
         ) {
           return;
         }
-
-        if (event.newValue === null) {
-          const fallback = getInitialValueRef.current();
-          setValue(fallback);
-          // Persist like the mount path so a reload reuses this anchor
-          // instead of minting a new one
-          window.localStorage.setItem(key, JSON.stringify(fallback));
-        } else {
-          setValue(JSON.parse(event.newValue));
-        }
       } catch {
-        // Ignore corrupted values written by other tabs
+        return;
       }
+      syncFromStorage();
     };
-    // Subscribe before reading so a write from another tab between the
-    // useState initializer and this effect cannot be missed
+    // Subscribe before the initial sync so a write from another tab between
+    // the useState initializer and this effect cannot be missed
     window.addEventListener('storage', handleStorage);
-
-    try {
-      const raw = window.localStorage.getItem(key);
-      let parsed: { value: T } | null = null;
-      if (raw !== null) {
-        try {
-          parsed = { value: JSON.parse(raw) };
-        } catch {
-          // Corrupted entry (the #92 scenario); replace below so the
-          // fallback value persists instead of being recomputed every load
-        }
-      }
-      if (parsed === null) {
-        // Key missing now — either it never existed or another tab removed
-        // it after the initializer ran. Either way, derive a fresh fallback
-        // and sync state and storage to the same value: never resurrect a
-        // deleted entry, and keep the running countdown identical to the
-        // persisted anchor.
-        const fallback = getInitialValueRef.current();
-        setValue(fallback);
-        window.localStorage.setItem(key, JSON.stringify(fallback));
-      } else {
-        // Re-sync in case another tab wrote after the initializer ran
-        setValue(parsed.value);
-      }
-    } catch {
-      // Storage unavailable; keep in-memory state only
-    }
+    syncFromStorage();
 
     return () => window.removeEventListener('storage', handleStorage);
   }, [key]);

--- a/app/lookup/[domain]/_components/star-reminder.tsx
+++ b/app/lookup/[domain]/_components/star-reminder.tsx
@@ -29,13 +29,21 @@ const SKIP_BUTTON_DELAY = ms('5s');
 // factory so time-derived fallbacks (the reminder delay anchor) are computed
 // fresh whenever they are needed, not captured at render time.
 const useSafeLocalStorage = <T,>(key: string, getInitialValue: () => T) => {
+  // Whether the initializer fell back (missing key, corrupt value, or
+  // blocked storage) rather than reading a stored value; idempotent ref
+  // write, so safe under StrictMode double-invocation
+  const usedFallbackRef = useRef(false);
   const [value, setValue] = useState<T>(() => {
     try {
       const raw = window.localStorage.getItem(key);
-      return raw === null ? getInitialValue() : JSON.parse(raw);
+      if (raw !== null) {
+        return JSON.parse(raw);
+      }
     } catch {
-      return getInitialValue();
+      // Blocked storage or corrupt value; fall through to the fallback
     }
+    usedFallbackRef.current = true;
+    return getInitialValue();
   });
 
   // The factory only closes over module constants, so the mount-time one
@@ -91,7 +99,15 @@ const useSafeLocalStorage = <T,>(key: string, getInitialValue: () => T) => {
         }
       }
       if (parsed === null) {
-        window.localStorage.setItem(key, JSON.stringify(mountValueRef.current));
+        // If the initializer had read a valid value, another tab removed the
+        // key in between — derive a fresh fallback like the storage-event
+        // path instead of resurrecting the deleted value. Otherwise persist
+        // the initializer's own fallback.
+        const fallback = usedFallbackRef.current
+          ? mountValueRef.current
+          : getInitialValueRef.current();
+        setValue(fallback);
+        window.localStorage.setItem(key, JSON.stringify(fallback));
       } else {
         // Re-sync in case another tab wrote after the initializer ran
         setValue(parsed.value);

--- a/app/lookup/[domain]/_components/star-reminder.tsx
+++ b/app/lookup/[domain]/_components/star-reminder.tsx
@@ -29,29 +29,18 @@ const SKIP_BUTTON_DELAY = ms('5s');
 // factory so time-derived fallbacks (the reminder delay anchor) are computed
 // fresh whenever they are needed, not captured at render time.
 const useSafeLocalStorage = <T,>(key: string, getInitialValue: () => T) => {
-  // Whether the initializer fell back (missing key, corrupt value, or
-  // blocked storage) rather than reading a stored value; idempotent ref
-  // write, so safe under StrictMode double-invocation
-  const usedFallbackRef = useRef(false);
   const [value, setValue] = useState<T>(() => {
     try {
       const raw = window.localStorage.getItem(key);
-      if (raw !== null) {
-        return JSON.parse(raw);
-      }
+      return raw === null ? getInitialValue() : JSON.parse(raw);
     } catch {
-      // Blocked storage or corrupt value; fall through to the fallback
+      return getInitialValue();
     }
-    usedFallbackRef.current = true;
-    return getInitialValue();
   });
 
   // The factory only closes over module constants, so the mount-time one
   // stays correct for the storage handlers below
   const getInitialValueRef = useRef(getInitialValue);
-  // What the initializer produced, so the mount repair below persists the
-  // exact anchor the countdown is already using
-  const mountValueRef = useRef(value);
 
   // Match the replaced hook: persist the initial value so time-based state
   // (the reminder delay anchor) survives reloads, and follow changes made in
@@ -99,13 +88,12 @@ const useSafeLocalStorage = <T,>(key: string, getInitialValue: () => T) => {
         }
       }
       if (parsed === null) {
-        // If the initializer had read a valid value, another tab removed the
-        // key in between — derive a fresh fallback like the storage-event
-        // path instead of resurrecting the deleted value. Otherwise persist
-        // the initializer's own fallback.
-        const fallback = usedFallbackRef.current
-          ? mountValueRef.current
-          : getInitialValueRef.current();
+        // Key missing now — either it never existed or another tab removed
+        // it after the initializer ran. Either way, derive a fresh fallback
+        // and sync state and storage to the same value: never resurrect a
+        // deleted entry, and keep the running countdown identical to the
+        // persisted anchor.
+        const fallback = getInitialValueRef.current();
         setValue(fallback);
         window.localStorage.setItem(key, JSON.stringify(fallback));
       } else {

--- a/app/lookup/[domain]/_components/star-reminder.tsx
+++ b/app/lookup/[domain]/_components/star-reminder.tsx
@@ -41,6 +41,9 @@ const useSafeLocalStorage = <T,>(key: string, getInitialValue: () => T) => {
   // The factory only closes over module constants, so the mount-time one
   // stays correct for the storage handlers below
   const getInitialValueRef = useRef(getInitialValue);
+  // What the initializer produced, so the mount repair below persists the
+  // exact anchor the countdown is already using
+  const mountValueRef = useRef(value);
 
   // Match the replaced hook: persist the initial value so time-based state
   // (the reminder delay anchor) survives reloads, and follow changes made in
@@ -59,11 +62,15 @@ const useSafeLocalStorage = <T,>(key: string, getInitialValue: () => T) => {
           return;
         }
 
-        setValue(
-          event.newValue === null
-            ? getInitialValueRef.current()
-            : JSON.parse(event.newValue),
-        );
+        if (event.newValue === null) {
+          const fallback = getInitialValueRef.current();
+          setValue(fallback);
+          // Persist like the mount path so a reload reuses this anchor
+          // instead of minting a new one
+          window.localStorage.setItem(key, JSON.stringify(fallback));
+        } else {
+          setValue(JSON.parse(event.newValue));
+        }
       } catch {
         // Ignore corrupted values written by other tabs
       }
@@ -84,10 +91,7 @@ const useSafeLocalStorage = <T,>(key: string, getInitialValue: () => T) => {
         }
       }
       if (parsed === null) {
-        window.localStorage.setItem(
-          key,
-          JSON.stringify(getInitialValueRef.current()),
-        );
+        window.localStorage.setItem(key, JSON.stringify(mountValueRef.current));
       } else {
         // Re-sync in case another tab wrote after the initializer ran
         setValue(parsed.value);

--- a/app/lookup/[domain]/_components/star-reminder.tsx
+++ b/app/lookup/[domain]/_components/star-reminder.tsx
@@ -36,14 +36,30 @@ const useSafeLocalStorage = <T,>(key: string, initialValue: T) => {
     }
   });
 
+  // Latest-ref so the storage handlers below use the freshest initial value;
+  // lastDismissed's initial value is time-derived and recomputed every render
   const initialValueRef = useRef(initialValue);
+  useEffect(() => {
+    initialValueRef.current = initialValue;
+  });
 
   // Match the replaced hook: persist the initial value so time-based state
   // (the reminder delay anchor) survives reloads, and follow changes made in
   // other tabs
   useEffect(() => {
     try {
-      if (window.localStorage.getItem(key) === null) {
+      const raw = window.localStorage.getItem(key);
+      let isValid = false;
+      if (raw !== null) {
+        try {
+          JSON.parse(raw);
+          isValid = true;
+        } catch {
+          // Corrupted entry (the #92 scenario); replace below so the
+          // fallback value persists instead of being recomputed every load
+        }
+      }
+      if (!isValid) {
         window.localStorage.setItem(
           key,
           JSON.stringify(initialValueRef.current),

--- a/app/lookup/[domain]/_components/star-reminder.tsx
+++ b/app/lookup/[domain]/_components/star-reminder.tsx
@@ -47,28 +47,6 @@ const useSafeLocalStorage = <T,>(key: string, initialValue: T) => {
   // (the reminder delay anchor) survives reloads, and follow changes made in
   // other tabs
   useEffect(() => {
-    try {
-      const raw = window.localStorage.getItem(key);
-      let isValid = false;
-      if (raw !== null) {
-        try {
-          JSON.parse(raw);
-          isValid = true;
-        } catch {
-          // Corrupted entry (the #92 scenario); replace below so the
-          // fallback value persists instead of being recomputed every load
-        }
-      }
-      if (!isValid) {
-        window.localStorage.setItem(
-          key,
-          JSON.stringify(initialValueRef.current),
-        );
-      }
-    } catch {
-      // Storage unavailable; keep in-memory state only
-    }
-
     const handleStorage = (event: StorageEvent) => {
       if (event.key !== key || event.storageArea !== window.localStorage) {
         return;
@@ -84,7 +62,34 @@ const useSafeLocalStorage = <T,>(key: string, initialValue: T) => {
         // Ignore corrupted values written by other tabs
       }
     };
+    // Subscribe before reading so a write from another tab between the
+    // useState initializer and this effect cannot be missed
     window.addEventListener('storage', handleStorage);
+
+    try {
+      const raw = window.localStorage.getItem(key);
+      let parsed: { value: T } | null = null;
+      if (raw !== null) {
+        try {
+          parsed = { value: JSON.parse(raw) };
+        } catch {
+          // Corrupted entry (the #92 scenario); replace below so the
+          // fallback value persists instead of being recomputed every load
+        }
+      }
+      if (parsed === null) {
+        window.localStorage.setItem(
+          key,
+          JSON.stringify(initialValueRef.current),
+        );
+      } else {
+        // Re-sync in case another tab wrote after the initializer ran
+        setValue(parsed.value);
+      }
+    } catch {
+      // Storage unavailable; keep in-memory state only
+    }
+
     return () => window.removeEventListener('storage', handleStorage);
   }, [key]);
 

--- a/lib/use-safe-local-storage.test.ts
+++ b/lib/use-safe-local-storage.test.ts
@@ -1,0 +1,157 @@
+import { act, createElement, useEffect } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { useSafeLocalStorage } from './use-safe-local-storage';
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const KEY = 'test.key';
+
+const mounted: Array<() => void> = [];
+
+const renderHook = <T>(getInitialValue: () => T) => {
+  const resultRef = {
+    current: null as unknown as readonly [T, (next: T) => void],
+  };
+  const Probe = () => {
+    const hookResult = useSafeLocalStorage(KEY, getInitialValue);
+    // Render-phase writes to outer variables are rejected by the React
+    // Compiler lint; effects run within act(), so the capture is in time
+    useEffect(() => {
+      resultRef.current = hookResult;
+    });
+    return null;
+  };
+  const root = createRoot(document.createElement('div'));
+  act(() => root.render(createElement(Probe)));
+  mounted.push(() => act(() => root.unmount()));
+  return { result: resultRef };
+};
+
+const originalLocalStorage = window.localStorage;
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  // Unmount before restoring localStorage so lingering storage listeners
+  // from one test cannot react to events dispatched in the next
+  mounted.forEach((unmount) => unmount());
+  mounted.length = 0;
+  Object.defineProperty(window, 'localStorage', {
+    value: originalLocalStorage,
+    configurable: true,
+    writable: true,
+  });
+});
+
+describe('useSafeLocalStorage', () => {
+  it('returns the stored value when present', () => {
+    window.localStorage.setItem(KEY, JSON.stringify(42));
+    const { result } = renderHook(() => 0);
+    expect(result.current[0]).toBe(42);
+  });
+
+  it('falls back and persists the initial value when the key is missing', () => {
+    const { result } = renderHook(() => 7);
+    expect(result.current[0]).toBe(7);
+    expect(window.localStorage.getItem(KEY)).toBe('7');
+  });
+
+  it('repairs corrupted values instead of crashing (#92)', () => {
+    window.localStorage.setItem(KEY, 'not-valid-json{');
+    const { result } = renderHook(() => 'fallback');
+    expect(result.current[0]).toBe('fallback');
+    expect(window.localStorage.getItem(KEY)).toBe('"fallback"');
+  });
+
+  it('falls back without crashing when storage access is denied', () => {
+    Object.defineProperty(window, 'localStorage', {
+      get() {
+        throw new DOMException('Access is denied', 'SecurityError');
+      },
+      configurable: true,
+    });
+    const { result } = renderHook(() => 'safe');
+    expect(result.current[0]).toBe('safe');
+  });
+
+  it('set() updates state and persists', () => {
+    const { result } = renderHook(() => false);
+    act(() => result.current[1](true));
+    expect(result.current[0]).toBe(true);
+    expect(window.localStorage.getItem(KEY)).toBe('true');
+  });
+
+  it('syncs from storage when another tab writes', () => {
+    const { result } = renderHook(() => 'initial');
+    window.localStorage.setItem(KEY, JSON.stringify('from-other-tab'));
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: KEY,
+          newValue: JSON.stringify('from-other-tab'),
+          storageArea: window.localStorage,
+        }),
+      );
+    });
+    expect(result.current[0]).toBe('from-other-tab');
+  });
+
+  it('reads storage as the authority, not the event payload', () => {
+    const { result } = renderHook(() => 'initial');
+    window.localStorage.setItem(KEY, JSON.stringify('latest'));
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: KEY,
+          newValue: JSON.stringify('stale'),
+          storageArea: window.localStorage,
+        }),
+      );
+    });
+    expect(result.current[0]).toBe('latest');
+  });
+
+  it('derives and persists a fresh fallback on cross-tab clear()', () => {
+    let calls = 0;
+    const { result } = renderHook(() => {
+      calls += 1;
+      return `fallback-${calls}`;
+    });
+    act(() => result.current[1]('written'));
+    window.localStorage.clear();
+    act(() => {
+      // clear() in another tab emits a storage event with a null key
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: null,
+          newValue: null,
+          storageArea: window.localStorage,
+        }),
+      );
+    });
+    const [value] = result.current;
+    expect(value).toMatch(/^fallback-/);
+    expect(value).not.toBe('written');
+    expect(window.localStorage.getItem(KEY)).toBe(JSON.stringify(value));
+  });
+
+  it('ignores storage events for other keys', () => {
+    const { result } = renderHook(() => 'mine');
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: 'other.key',
+          newValue: '"other"',
+          storageArea: window.localStorage,
+        }),
+      );
+    });
+    expect(result.current[0]).toBe('mine');
+  });
+});

--- a/lib/use-safe-local-storage.ts
+++ b/lib/use-safe-local-storage.ts
@@ -1,0 +1,87 @@
+import { useEffect, useRef, useState } from 'react';
+
+// Unlike @uidotdev/usehooks' useLocalStorage, this survives blocked storage
+// access (throws SecurityError) and corrupted values (JSON.parse throws),
+// both of which crashed the page during render (#92). The initial value is a
+// factory so time-derived fallbacks (e.g. a reminder delay anchor) are
+// computed fresh whenever they are needed, not captured at render time.
+export const useSafeLocalStorage = <T>(
+  key: string,
+  getInitialValue: () => T,
+) => {
+  const [value, setValue] = useState<T>(() => {
+    try {
+      const raw = window.localStorage.getItem(key);
+      return raw === null ? getInitialValue() : JSON.parse(raw);
+    } catch {
+      return getInitialValue();
+    }
+  });
+
+  // The factory only closes over constants, so the mount-time one stays
+  // correct for the storage handlers below
+  const getInitialValueRef = useRef(getInitialValue);
+
+  // Match the replaced hook: persist the initial value so time-based state
+  // survives reloads, and follow changes made in other tabs
+  useEffect(() => {
+    // Storage itself is the authority; events only signal that it changed.
+    // Reading it fresh (instead of trusting event.newValue) keeps
+    // concurrently-writing tabs convergent, and a missing or corrupt entry
+    // is repaired with a fresh fallback so state and storage always hold
+    // the same value — a deleted entry is never resurrected.
+    const syncFromStorage = () => {
+      try {
+        const raw = window.localStorage.getItem(key);
+        if (raw !== null) {
+          try {
+            setValue(JSON.parse(raw));
+            return;
+          } catch {
+            // Corrupted entry (the #92 scenario); repair below
+          }
+        }
+        const fallback = getInitialValueRef.current();
+        setValue(fallback);
+        window.localStorage.setItem(key, JSON.stringify(fallback));
+      } catch {
+        // Storage unavailable; keep in-memory state only
+      }
+    };
+
+    const handleStorage = (event: StorageEvent) => {
+      try {
+        // Accessing window.localStorage can itself throw when storage is
+        // denied, so the guard stays inside a try. A null key means
+        // localStorage.clear() was called in another tab, which also
+        // affects this entry.
+        if (
+          (event.key !== null && event.key !== key) ||
+          event.storageArea !== window.localStorage
+        ) {
+          return;
+        }
+      } catch {
+        return;
+      }
+      syncFromStorage();
+    };
+    // Subscribe before the initial sync so a write from another tab between
+    // the useState initializer and this effect cannot be missed
+    window.addEventListener('storage', handleStorage);
+    syncFromStorage();
+
+    return () => window.removeEventListener('storage', handleStorage);
+  }, [key]);
+
+  const set = (next: T) => {
+    setValue(next);
+    try {
+      window.localStorage.setItem(key, JSON.stringify(next));
+    } catch {
+      // Storage unavailable; state still updates for the current page view
+    }
+  };
+
+  return [value, set] as const;
+};


### PR DESCRIPTION
Fixes #92

## Problem

`useLocalStorage` from `@uidotdev/usehooks` throws **during render** in two situations:

- `window.localStorage` access is denied (browsers with all cookies blocked, strict privacy configurations — the second report in #92 is Brave)
- a stored value is not valid JSON (`JSON.parse` has no try/catch in the hook)

`StarReminder` mounts on every `/lookup/*` page and is rendered by the segment **layout**, so the error bubbles past `lookup/[domain]/error.tsx` into the root boundary — the full-page "Something went VERY wrong!" screen. Reproduced locally by setting `star-reminder.starred` to a non-JSON string and reloading a lookup page: pixel-for-pixel the reported error page, with the stack pointing at `JSON.parse → useLocalStorage → StarReminder`.

## Fix

Replace the library hook with a minimal local `useSafeLocalStorage` that falls back to the initial value on any storage failure and swallows write errors. No behavior change for users with working storage.

## Verification

Repeated the repro with both keys corrupted — the lookup page now renders fully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQ8MVRG4QUiH67qKtm972F

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces `@uidotdev/usehooks` `useLocalStorage` with a safe hook to stop `/lookup/*` crashes when storage is blocked or values are corrupted. Extracts the hook to `lib/use-safe-local-storage` with tests, and restores persisted delay anchoring and reliable cross‑tab sync.

- **Bug Fixes**
  - No render throws when storage is denied or JSON is bad; falls back to initial values and keeps in‑memory state if writes fail, preventing `StarReminder` crashes (fixes #92).
  - Cross‑tab behavior is consistent: subscribe‑before‑read; `storage` events trigger a fresh re‑read (ignore event.newValue); handle `removeItem` and `localStorage.clear()`; repair corrupt entries from other tabs; compute time‑based fallbacks at use time; never resurrect deleted values; keep the persisted anchor aligned with the in‑memory countdown.

- **Refactors**
  - Moved `useSafeLocalStorage` into `lib` with unit tests; no new dependencies.

<sup>Written for commit 6a326cef49ab826821edc6b6e5655ad5202850d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wotschofsky/domain-digger/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

