### PR TITLE
Forward client-side logs to the server 📡🪵

### DIFF
--- a/app/api/evlog/ingest/route.ts
+++ b/app/api/evlog/ingest/route.ts
@@ -32,6 +32,15 @@ export const POST = withEvlog(async (request: Request) => {
     return NextResponse.json({ error: 'Invalid origin' }, { status: 403 });
   }
 
+  // Check the declared size before buffering the body; clients that lie or
+  // send chunked requests are caught by the length check after reading, with
+  // the platform's request-size cap bounding the worst case in between
+  const contentLength = Number(request.headers.get('content-length'));
+  if (contentLength > MAX_BODY_LENGTH) {
+    requestLog.set({ status: 413, reason: 'payload_too_large' });
+    return NextResponse.json({ error: 'Payload too large' }, { status: 413 });
+  }
+
   const raw = await request.text();
   if (raw.length > MAX_BODY_LENGTH) {
     requestLog.set({ status: 413, reason: 'payload_too_large' });

--- a/app/api/evlog/ingest/route.ts
+++ b/app/api/evlog/ingest/route.ts
@@ -1,31 +1,57 @@
 import { NextResponse } from 'next/server';
 
-import { log, withEvlog } from '@/lib/evlog';
+import { log, useLogger, withEvlog } from '@/lib/evlog';
 
-// Receives client-side logs from evlog's browser transport (see EvlogProvider
-// in app/providers.tsx) and forwards them into the server logging pipeline
+// Receives client-side logs from evlog's browser transport (see
+// app/providers.tsx) and forwards them into the server logging pipeline
 const LEVELS = ['debug', 'info', 'warn', 'error'] as const;
 type Level = (typeof LEVELS)[number];
 
 const isLevel = (value: unknown): value is Level =>
   LEVELS.includes(value as Level);
 
+const MAX_BODY_LENGTH = 32_768;
+
 export const POST = withEvlog(async (request: Request) => {
-  // Public endpoint; only accept logs sent from our own pages
+  const requestLog = useLogger();
+
+  // Public endpoint; only accept logs sent from our own pages. The origin
+  // check stops browsers, not scripted clients that forge the header.
+  // ponytail: no rate limiting — if log flooding ever becomes a problem, add
+  // it at the edge (e.g. Vercel WAF) rather than in the handler
   const origin =
     request.headers.get('origin') ?? request.headers.get('referer');
   const host = request.headers.get('host');
-  if (!origin || !host || new URL(origin).host !== host) {
+  if (
+    !origin ||
+    !host ||
+    !URL.canParse(origin) ||
+    new URL(origin).host !== host
+  ) {
+    requestLog.set({ status: 403, reason: 'invalid_origin' });
     return NextResponse.json({ error: 'Invalid origin' }, { status: 403 });
   }
 
-  const body: unknown = await request.json().catch(() => null);
+  const raw = await request.text();
+  if (raw.length > MAX_BODY_LENGTH) {
+    requestLog.set({ status: 413, reason: 'payload_too_large' });
+    return NextResponse.json({ error: 'Payload too large' }, { status: 413 });
+  }
+
+  let body: unknown = null;
+  try {
+    body = JSON.parse(raw);
+  } catch {
+    // Handled by the object check below
+  }
   if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    requestLog.set({ status: 400, reason: 'invalid_payload' });
     return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
   }
 
   const { level, ...event } = body as Record<string, unknown>;
   if (!isLevel(level)) {
+    requestLog.set({ status: 400, reason: 'invalid_level' });
     return NextResponse.json({ error: 'Invalid level' }, { status: 400 });
   }
 

--- a/app/api/evlog/ingest/route.ts
+++ b/app/api/evlog/ingest/route.ts
@@ -66,6 +66,25 @@ export const POST = withEvlog(async (request: Request) => {
 
   // The server logger sets its own service field
   delete event.service;
+
+  // Normalize like evlog's reference ingest handler: drop malformed or
+  // implausible timestamps so forged values cannot corrupt downstream drains
+  const { timestamp } = event;
+  const parsedTimestamp =
+    typeof timestamp === 'string' || typeof timestamp === 'number'
+      ? new Date(timestamp)
+      : null;
+  if (
+    parsedTimestamp === null ||
+    Number.isNaN(parsedTimestamp.getTime()) ||
+    parsedTimestamp.getTime() < Date.parse('2000-01-01') ||
+    parsedTimestamp.getTime() > Date.now() + 24 * 60 * 60 * 1000
+  ) {
+    delete event.timestamp;
+  } else {
+    event.timestamp = parsedTimestamp.toISOString();
+  }
+
   log[level]({ ...event, source: 'client' });
 
   return new NextResponse(null, { status: 204 });

--- a/app/api/evlog/ingest/route.ts
+++ b/app/api/evlog/ingest/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+
+import { log, withEvlog } from '@/lib/evlog';
+
+// Receives client-side logs from evlog's browser transport (see EvlogProvider
+// in app/providers.tsx) and forwards them into the server logging pipeline
+const LEVELS = ['debug', 'info', 'warn', 'error'] as const;
+type Level = (typeof LEVELS)[number];
+
+const isLevel = (value: unknown): value is Level =>
+  LEVELS.includes(value as Level);
+
+export const POST = withEvlog(async (request: Request) => {
+  // Public endpoint; only accept logs sent from our own pages
+  const origin =
+    request.headers.get('origin') ?? request.headers.get('referer');
+  const host = request.headers.get('host');
+  if (!origin || !host || new URL(origin).host !== host) {
+    return NextResponse.json({ error: 'Invalid origin' }, { status: 403 });
+  }
+
+  const body: unknown = await request.json().catch(() => null);
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+
+  const { level, ...event } = body as Record<string, unknown>;
+  if (!isLevel(level)) {
+    return NextResponse.json({ error: 'Invalid level' }, { status: 400 });
+  }
+
+  // The server logger sets its own service field
+  delete event.service;
+  log[level]({ ...event, source: 'client' });
+
+  return new NextResponse(null, { status: 204 });
+});

--- a/app/api/evlog/ingest/route.ts
+++ b/app/api/evlog/ingest/route.ts
@@ -42,7 +42,7 @@ export const POST = withEvlog(async (request: Request) => {
   }
 
   const raw = await request.text();
-  if (raw.length > MAX_BODY_LENGTH) {
+  if (Buffer.byteLength(raw, 'utf8') > MAX_BODY_LENGTH) {
     requestLog.set({ status: 413, reason: 'payload_too_large' });
     return NextResponse.json({ error: 'Payload too large' }, { status: 413 });
   }

--- a/app/api/evlog/ingest/route.ts
+++ b/app/api/evlog/ingest/route.ts
@@ -64,8 +64,15 @@ export const POST = withEvlog(async (request: Request) => {
     return NextResponse.json({ error: 'Invalid level' }, { status: 400 });
   }
 
-  // The server logger sets its own service field
+  // Server-owned fields: the logger stamps its own environment context, and
+  // `audit` triggers evlog's audit pipeline, which expects a shape a forged
+  // request need not provide (unguarded audit.actor.type access throws)
   delete event.service;
+  delete event.environment;
+  delete event.version;
+  delete event.commitHash;
+  delete event.region;
+  delete event.audit;
 
   // Normalize like evlog's reference ingest handler: drop malformed or
   // implausible timestamps so forged values cannot corrupt downstream drains
@@ -85,7 +92,13 @@ export const POST = withEvlog(async (request: Request) => {
     event.timestamp = parsedTimestamp.toISOString();
   }
 
-  log[level]({ ...event, source: 'client' });
+  try {
+    log[level]({ ...event, source: 'client' });
+  } catch {
+    // Never let a hostile payload shape turn into a 500 from the logger
+    requestLog.set({ status: 400, reason: 'unloggable_payload' });
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+  }
 
   return new NextResponse(null, { status: 204 });
 });

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,12 +1,25 @@
 'use client';
 
-import { EvlogProvider } from 'evlog/next/client';
+import { initLog } from 'evlog/client';
 import PlausibleProvider from 'next-plausible';
 import { ThemeProvider } from 'next-themes';
 import { type FC, type ReactNode } from 'react';
 import { SWRConfig } from 'swr';
 
 import { env } from '@/env';
+
+// Initialize client logging eagerly at module scope instead of via
+// EvlogProvider: React runs child effects before parent effects, so an error
+// boundary logging a crash during the initial page load would fire before a
+// provider effect could enable the transport, silently dropping the event.
+// The endpoint deviates from evlog's default /api/_evlog/ingest because
+// Next.js excludes underscore-prefixed folders from routing.
+if (typeof window !== 'undefined') {
+  initLog({
+    service: 'domain-digger',
+    transport: { enabled: true, endpoint: '/api/evlog/ingest' },
+  });
+}
 
 type CustomizedPlausibleProviderProps = {
   children: ReactNode;
@@ -42,16 +55,9 @@ type ProvidersProps = {
 };
 
 export const Providers: FC<ProvidersProps> = ({ children }) => (
-  <EvlogProvider
-    service="domain-digger"
-    // Default endpoint is /api/_evlog/ingest, but Next.js excludes
-    // underscore-prefixed folders from routing
-    transport={{ enabled: true, endpoint: '/api/evlog/ingest' }}
-  >
-    <ThemeProvider attribute="class">
-      <SWRConfig value={{ fetcher: swrFetcher }}>
-        <CustomizedPlausibleProvider>{children}</CustomizedPlausibleProvider>
-      </SWRConfig>
-    </ThemeProvider>
-  </EvlogProvider>
+  <ThemeProvider attribute="class">
+    <SWRConfig value={{ fetcher: swrFetcher }}>
+      <CustomizedPlausibleProvider>{children}</CustomizedPlausibleProvider>
+    </SWRConfig>
+  </ThemeProvider>
 );

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -42,7 +42,12 @@ type ProvidersProps = {
 };
 
 export const Providers: FC<ProvidersProps> = ({ children }) => (
-  <EvlogProvider service="domain-digger">
+  <EvlogProvider
+    service="domain-digger"
+    // Default endpoint is /api/_evlog/ingest, but Next.js excludes
+    // underscore-prefixed folders from routing
+    transport={{ enabled: true, endpoint: '/api/evlog/ingest' }}
+  >
     <ThemeProvider attribute="class">
       <SWRConfig value={{ fetcher: swrFetcher }}>
         <CustomizedPlausibleProvider>{children}</CustomizedPlausibleProvider>


### PR DESCRIPTION
## Problem

The error boundaries already log client-side crashes via evlog (`boundary_error` with name, message, digest, and stack), but evlog's browser transport is **disabled by default** — those logs never left the affected user's console. That's why the crash behind #92 was invisible until someone filed an issue.

## Changes

- Enable the evlog client transport in `EvlogProvider`
- Add `POST /api/evlog/ingest`, which validates origin (same-host only) and log level, then forwards the event into the server logging pipeline tagged with `source: client`

The endpoint deviates from evlog's default `/api/_evlog/ingest` because Next.js excludes underscore-prefixed folders from routing (the default path 404s); the transport is pointed at the custom endpoint explicitly.

## Verification

Locally: client POST with a valid payload → 204 and the event appears in the server log with `source: client`; invalid level → 400; the route rejects cross-origin requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQ8MVRG4QUiH67qKtm972F

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward client-side `evlog` logs to the server to surface browser errors in production. Enables the transport early and adds a hardened same-origin ingest endpoint that normalizes timestamps and strips server-owned fields.

- **New Features**
  - Initialize `evlog` at module load via `initLog` with transport enabled and endpoint `/api/evlog/ingest` (custom path since Next.js excludes underscore routes); prevents dropping first-render boundary errors.
  - Add `POST /api/evlog/ingest`: same-origin only (`Origin`/`Referer` vs `Host`), 32KB byte cap (`Content-Length` + `Buffer.byteLength`), validates `level`, strips server-owned fields (`service`, `environment`, `version`, `commitHash`, `region`, `audit`), normalizes or drops client `timestamp` (ISO, plausible range), wraps the forward call to avoid 500s, forwards with `source: client`, logs rejections with `{ status, reason }`, returns 204.

<sup>Written for commit fcee1d570dbd2785ec58563ba7cf3532c0c4a405. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wotschofsky/domain-digger/pull/95?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

