### PR TITLE
Extract useSafeLocalStorage into lib with tests 📦🧪

### DIFF
--- a/app/lookup/[domain]/_components/star-reminder.tsx
+++ b/app/lookup/[domain]/_components/star-reminder.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import ms from 'ms';
-import { type FC, useEffect, useRef, useState } from 'react';
+import { type FC, useEffect, useState } from 'react';
 import { FaGithub } from 'react-icons/fa';
 
 import {
@@ -17,95 +17,12 @@ import {
 
 import { useStargazersSummary } from '@/app/api/stargazers-summary/hook';
 import { useAnalytics } from '@/lib/analytics';
+import { useSafeLocalStorage } from '@/lib/use-safe-local-storage';
 import { cn } from '@/lib/utils';
 
 const INITIAL_DELAY = ms('2m');
 const TIMEOUT_PERIOD = ms('7d');
 const SKIP_BUTTON_DELAY = ms('5s');
-
-// Unlike @uidotdev/usehooks' useLocalStorage, this survives blocked storage
-// access (throws SecurityError) and corrupted values (JSON.parse throws),
-// both of which crashed the page during render (#92). The initial value is a
-// factory so time-derived fallbacks (the reminder delay anchor) are computed
-// fresh whenever they are needed, not captured at render time.
-const useSafeLocalStorage = <T,>(key: string, getInitialValue: () => T) => {
-  const [value, setValue] = useState<T>(() => {
-    try {
-      const raw = window.localStorage.getItem(key);
-      return raw === null ? getInitialValue() : JSON.parse(raw);
-    } catch {
-      return getInitialValue();
-    }
-  });
-
-  // The factory only closes over module constants, so the mount-time one
-  // stays correct for the storage handlers below
-  const getInitialValueRef = useRef(getInitialValue);
-
-  // Match the replaced hook: persist the initial value so time-based state
-  // (the reminder delay anchor) survives reloads, and follow changes made in
-  // other tabs
-  useEffect(() => {
-    // Storage itself is the authority; events only signal that it changed.
-    // Reading it fresh (instead of trusting event.newValue) keeps
-    // concurrently-writing tabs convergent, and a missing or corrupt entry
-    // is repaired with a fresh fallback so state and storage always hold
-    // the same value — a deleted entry is never resurrected.
-    const syncFromStorage = () => {
-      try {
-        const raw = window.localStorage.getItem(key);
-        if (raw !== null) {
-          try {
-            setValue(JSON.parse(raw));
-            return;
-          } catch {
-            // Corrupted entry (the #92 scenario); repair below
-          }
-        }
-        const fallback = getInitialValueRef.current();
-        setValue(fallback);
-        window.localStorage.setItem(key, JSON.stringify(fallback));
-      } catch {
-        // Storage unavailable; keep in-memory state only
-      }
-    };
-
-    const handleStorage = (event: StorageEvent) => {
-      try {
-        // Accessing window.localStorage can itself throw when storage is
-        // denied, so the guard stays inside a try. A null key means
-        // localStorage.clear() was called in another tab, which also
-        // affects this entry.
-        if (
-          (event.key !== null && event.key !== key) ||
-          event.storageArea !== window.localStorage
-        ) {
-          return;
-        }
-      } catch {
-        return;
-      }
-      syncFromStorage();
-    };
-    // Subscribe before the initial sync so a write from another tab between
-    // the useState initializer and this effect cannot be missed
-    window.addEventListener('storage', handleStorage);
-    syncFromStorage();
-
-    return () => window.removeEventListener('storage', handleStorage);
-  }, [key]);
-
-  const set = (next: T) => {
-    setValue(next);
-    try {
-      window.localStorage.setItem(key, JSON.stringify(next));
-    } catch {
-      // Storage unavailable; state still updates for the current page view
-    }
-  };
-
-  return [value, set] as const;
-};
 
 export const StarReminder: FC = () => {
   const { reportEvent } = useAnalytics();

--- a/lib/use-safe-local-storage.test.ts
+++ b/lib/use-safe-local-storage.test.ts
@@ -1,0 +1,157 @@
+import { act, createElement, useEffect } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { useSafeLocalStorage } from './use-safe-local-storage';
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const KEY = 'test.key';
+
+const mounted: Array<() => void> = [];
+
+const renderHook = <T>(getInitialValue: () => T) => {
+  const resultRef = {
+    current: null as unknown as readonly [T, (next: T) => void],
+  };
+  const Probe = () => {
+    const hookResult = useSafeLocalStorage(KEY, getInitialValue);
+    // Render-phase writes to outer variables are rejected by the React
+    // Compiler lint; effects run within act(), so the capture is in time
+    useEffect(() => {
+      resultRef.current = hookResult;
+    });
+    return null;
+  };
+  const root = createRoot(document.createElement('div'));
+  act(() => root.render(createElement(Probe)));
+  mounted.push(() => act(() => root.unmount()));
+  return { result: resultRef };
+};
+
+const originalLocalStorage = window.localStorage;
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  // Unmount before restoring localStorage so lingering storage listeners
+  // from one test cannot react to events dispatched in the next
+  mounted.forEach((unmount) => unmount());
+  mounted.length = 0;
+  Object.defineProperty(window, 'localStorage', {
+    value: originalLocalStorage,
+    configurable: true,
+    writable: true,
+  });
+});
+
+describe('useSafeLocalStorage', () => {
+  it('returns the stored value when present', () => {
+    window.localStorage.setItem(KEY, JSON.stringify(42));
+    const { result } = renderHook(() => 0);
+    expect(result.current[0]).toBe(42);
+  });
+
+  it('falls back and persists the initial value when the key is missing', () => {
+    const { result } = renderHook(() => 7);
+    expect(result.current[0]).toBe(7);
+    expect(window.localStorage.getItem(KEY)).toBe('7');
+  });
+
+  it('repairs corrupted values instead of crashing (#92)', () => {
+    window.localStorage.setItem(KEY, 'not-valid-json{');
+    const { result } = renderHook(() => 'fallback');
+    expect(result.current[0]).toBe('fallback');
+    expect(window.localStorage.getItem(KEY)).toBe('"fallback"');
+  });
+
+  it('falls back without crashing when storage access is denied', () => {
+    Object.defineProperty(window, 'localStorage', {
+      get() {
+        throw new DOMException('Access is denied', 'SecurityError');
+      },
+      configurable: true,
+    });
+    const { result } = renderHook(() => 'safe');
+    expect(result.current[0]).toBe('safe');
+  });
+
+  it('set() updates state and persists', () => {
+    const { result } = renderHook(() => false);
+    act(() => result.current[1](true));
+    expect(result.current[0]).toBe(true);
+    expect(window.localStorage.getItem(KEY)).toBe('true');
+  });
+
+  it('syncs from storage when another tab writes', () => {
+    const { result } = renderHook(() => 'initial');
+    window.localStorage.setItem(KEY, JSON.stringify('from-other-tab'));
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: KEY,
+          newValue: JSON.stringify('from-other-tab'),
+          storageArea: window.localStorage,
+        }),
+      );
+    });
+    expect(result.current[0]).toBe('from-other-tab');
+  });
+
+  it('reads storage as the authority, not the event payload', () => {
+    const { result } = renderHook(() => 'initial');
+    window.localStorage.setItem(KEY, JSON.stringify('latest'));
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: KEY,
+          newValue: JSON.stringify('stale'),
+          storageArea: window.localStorage,
+        }),
+      );
+    });
+    expect(result.current[0]).toBe('latest');
+  });
+
+  it('derives and persists a fresh fallback on cross-tab clear()', () => {
+    let calls = 0;
+    const { result } = renderHook(() => {
+      calls += 1;
+      return `fallback-${calls}`;
+    });
+    act(() => result.current[1]('written'));
+    window.localStorage.clear();
+    act(() => {
+      // clear() in another tab emits a storage event with a null key
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: null,
+          newValue: null,
+          storageArea: window.localStorage,
+        }),
+      );
+    });
+    const [value] = result.current;
+    expect(value).toMatch(/^fallback-/);
+    expect(value).not.toBe('written');
+    expect(window.localStorage.getItem(KEY)).toBe(JSON.stringify(value));
+  });
+
+  it('ignores storage events for other keys', () => {
+    const { result } = renderHook(() => 'mine');
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: 'other.key',
+          newValue: '"other"',
+          storageArea: window.localStorage,
+        }),
+      );
+    });
+    expect(result.current[0]).toBe('mine');
+  });
+});

--- a/lib/use-safe-local-storage.ts
+++ b/lib/use-safe-local-storage.ts
@@ -1,0 +1,87 @@
+import { useEffect, useRef, useState } from 'react';
+
+// Unlike @uidotdev/usehooks' useLocalStorage, this survives blocked storage
+// access (throws SecurityError) and corrupted values (JSON.parse throws),
+// both of which crashed the page during render (#92). The initial value is a
+// factory so time-derived fallbacks (e.g. a reminder delay anchor) are
+// computed fresh whenever they are needed, not captured at render time.
+export const useSafeLocalStorage = <T>(
+  key: string,
+  getInitialValue: () => T,
+) => {
+  const [value, setValue] = useState<T>(() => {
+    try {
+      const raw = window.localStorage.getItem(key);
+      return raw === null ? getInitialValue() : JSON.parse(raw);
+    } catch {
+      return getInitialValue();
+    }
+  });
+
+  // The factory only closes over constants, so the mount-time one stays
+  // correct for the storage handlers below
+  const getInitialValueRef = useRef(getInitialValue);
+
+  // Match the replaced hook: persist the initial value so time-based state
+  // survives reloads, and follow changes made in other tabs
+  useEffect(() => {
+    // Storage itself is the authority; events only signal that it changed.
+    // Reading it fresh (instead of trusting event.newValue) keeps
+    // concurrently-writing tabs convergent, and a missing or corrupt entry
+    // is repaired with a fresh fallback so state and storage always hold
+    // the same value — a deleted entry is never resurrected.
+    const syncFromStorage = () => {
+      try {
+        const raw = window.localStorage.getItem(key);
+        if (raw !== null) {
+          try {
+            setValue(JSON.parse(raw));
+            return;
+          } catch {
+            // Corrupted entry (the #92 scenario); repair below
+          }
+        }
+        const fallback = getInitialValueRef.current();
+        setValue(fallback);
+        window.localStorage.setItem(key, JSON.stringify(fallback));
+      } catch {
+        // Storage unavailable; keep in-memory state only
+      }
+    };
+
+    const handleStorage = (event: StorageEvent) => {
+      try {
+        // Accessing window.localStorage can itself throw when storage is
+        // denied, so the guard stays inside a try. A null key means
+        // localStorage.clear() was called in another tab, which also
+        // affects this entry.
+        if (
+          (event.key !== null && event.key !== key) ||
+          event.storageArea !== window.localStorage
+        ) {
+          return;
+        }
+      } catch {
+        return;
+      }
+      syncFromStorage();
+    };
+    // Subscribe before the initial sync so a write from another tab between
+    // the useState initializer and this effect cannot be missed
+    window.addEventListener('storage', handleStorage);
+    syncFromStorage();
+
+    return () => window.removeEventListener('storage', handleStorage);
+  }, [key]);
+
+  const set = (next: T) => {
+    setValue(next);
+    try {
+      window.localStorage.setItem(key, JSON.stringify(next));
+    } catch {
+      // Storage unavailable; state still updates for the current page view
+    }
+  };
+
+  return [value, set] as const;
+};


### PR DESCRIPTION
Stacked on #94 (base branch: `fix/star-reminder-storage-crash`) — merge that first, then retarget/merge this.

Moves the hook out of `star-reminder.tsx` into `lib/use-safe-local-storage.ts` (matching the `lib/analytics.ts` hook convention) and adds a vitest suite covering:

- reading a stored value
- fallback + persistence when the key is missing
- corrupted-value repair (the #92 scenario)
- denied storage access (SecurityError on `window.localStorage`)
- `set()` state + persistence
- cross-tab sync, including that storage is read as the authority rather than trusting the event payload
- fresh fallback persisted on cross-tab `clear()`
- ignoring events for other keys

Tests drive the hook through `react-dom` `createRoot` + `act` directly — no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQ8MVRG4QUiH67qKtm972F

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted `useSafeLocalStorage` into `lib/use-safe-local-storage.ts` and updated `StarReminder` to use it. Added tests to ensure robust behavior across blocked storage, corrupted values, and cross‑tab changes.

- **Refactors**
  - Replaced the inline hook in `star-reminder.tsx` with `useSafeLocalStorage` from `lib`.
  - Added `lib/use-safe-local-storage.test.ts` covering stored read, fallback + persistence, corruption repair, denied access, set() persistence, cross‑tab sync with storage as source of truth, clear() fallback, and key filtering.

<sup>Written for commit d104b8270748af0c5ce46296ca23b67e53e04011. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wotschofsky/domain-digger/pull/96?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

