### PR TITLE
Fix lookup pages crashing when GitHub returns no stargazers

### DIFF
--- a/app/lookup/[domain]/_components/star-reminder.tsx
+++ b/app/lookup/[domain]/_components/star-reminder.tsx
@@ -107,6 +107,13 @@ export const StarReminder: FC = () => {
     return null;
   }
 
+  const mostRecentStargazer = data.recentStargazers[0]?.name;
+
+  // check for truthy name to prevent "undefined and 3 others"
+  const stargazersMessage = mostRecentStargazer
+    ? `${mostRecentStargazer} and ${data.totalStars - 1} others\nhave recently starred Domain Digger`
+    : `${data.totalStars} people have starred Domain Digger`;
+
   return (
     <AlertDialog open={visible} onOpenChange={handleOpenChange}>
       <AlertDialogContent>
@@ -134,10 +141,8 @@ export const StarReminder: FC = () => {
                   />
                 ))}
               </div>
-              <p className="text-center">
-                {data.recentStargazers[0].name} and {data.totalStars - 1} others
-                <br />
-                have recently starred Domain Digger
+              <p className="text-center whitespace-pre-wrap">
+                {stargazersMessage}
               </p>
             </div>
           </AlertDialogDescription>


### PR DESCRIPTION
Fixes #92

## What happens

`StarReminder` reads `data.recentStargazers[0].name` unconditionally. When the API returns an empty `recentStargazers` array, that throws a `TypeError`, which propagates to the root `app/error.tsx` boundary and replaces the whole lookup page with "Something went VERY wrong!".

The dialog is gated on a 2 minute dwell and a 7 day cooldown, so it doesn't fire on every visit — which is why this reads as a random crash rather than a consistent one.

## Root cause

`recentStargazers` is sourced in `lib/github.ts` from the GitHub GraphQL API:

```graphql
repository(owner: $owner, name: $repo) {
  stargazerCount
  stargazers(first: $limit, orderBy: {field: STARRED_AT, direction: DESC}) {
    nodes { login name avatarUrl }
  }
}
```

GitHub has [restricted stargazer listing to admins and collaborators](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/). Running that exact query today, as a non-collaborator:

```
wotschofsky/domain-digger  → {"stargazerCount":1303,"stargazers":{"nodes":[]}}
facebook/react             → {"stargazerCount":246819,"stargazers":{"nodes":[]}}
vercel/next.js             → {"stargazerCount":141203,"stargazers":{"nodes":[]}}
```

The important detail is **how** it fails. The response is `HTTP 200` with no `errors` key, so neither of the existing guards in `getStargazersSummary` catches it:

- `!graphqlResponse.ok` → false, the response is a 200
- `result.errors` → undefined, GraphQL reports no error

An empty array sails straight through to the client. `repository.stargazerCount` still resolves, which is why the count renders fine while the names are gone. (`stargazers.totalCount` now hard-errors, and REST `/repos/{owner}/{repo}/stargazers` returns 404, but neither is on this code path.)

The restriction is scoped per caller, not per repo — a token with admin or collaborator standing still gets results:

```
LinusBolls/splid-js (30 stars) → nodes: [ben182, m4staka, Clusters, nxxqxxj, TP369]
```

So production kept working after GitHub shipped the GraphQL restriction, for as long as its `GITHUB_TOKEN` still counted as a collaborator on the repo, and started crashing when that stopped holding.

## Timeline

| When | What |
|---|---|
| 2026-06-30 | Changelog announces the restriction (REST endpoints) |
| 2026-07-07T06:06:42Z | First community report of the REST/UI breakage ([discussion #201178](https://github.com/orgs/community/discussions/201178)) |
| 2026-07-17T10:11:46Z | First public report of GraphQL being hit ([daily-stars-explorer#363](https://github.com/emanuelef/daily-stars-explorer/issues/363)) |
| 2026-07-29T22:48:10Z | #92 filed |

There is no exact rollout timestamp to point at. GitHub published none, there's no matching incident on githubstatus.com, and the failure is silent, so nothing in the response records the moment it flipped.

The one place the exact second *is* recorded is this repo's own telemetry. `app/api/stargazers-summary/route.ts` already logs it:

```ts
log.set({ stargazerCount: stargazers.recentStargazers.length });
```

The first evlog record where that value goes from `5` to `0` is the answer, for this deployment specifically.

## The fix

Guard the array access and build the message up front:

```ts
const mostRecentStargazer = data.recentStargazers[0]?.name;

const stargazersMessage = mostRecentStargazer
  ? `${mostRecentStargazer} and ${data.totalStars - 1} others\nhave recently starred Domain Digger`
  : `${data.totalStars} people have starred Domain Digger`;
```

The `<br />` is replaced by a `\n` plus `whitespace-pre-wrap`, since the line break now lives inside a string rather than in JSX. The `\n` is a real newline in the template literal and reaches the DOM intact — JSX whitespace trimming only applies to literal text children, not to strings passed through `{...}`. Verified in a browser: computed `white-space: pre-wrap`, text node contains the newline, and the paragraph measures 40px against a 20px line-height, i.e. two line boxes, matching the old `<br />` rendering.

The fallback copy drops "recently" and the `- 1`, because with nobody named there's no one to subtract, and `totalStars` is an all-time count rather than a recent one.

## Notes for the repo owner

Given the restriction is per-token, **the fallback branch is what renders in production right now**, not the edge case. The avatar row collapses to zero height, so the dialog is currently just a title and one line of text. Two things worth deciding on top of this PR:

1. **Restore the data.** Giving the production `GITHUB_TOKEN` admin or collaborator standing on `wotschofsky/domain-digger` brings the avatars and names back, and the primary branch renders again. Worth confirming which token the deployment actually uses.
2. **Decide what the degraded state should look like.** If the data isn't coming back, a dialog with no avatars may not be worth showing at all — returning `null` when `recentStargazers` is empty is a reasonable alternative to the fallback string. Happy to change this PR to that instead.

Separately, `getStargazersSummary` currently treats "200 with an empty list" as success. It might be worth failing loudly there instead, so this surfaces as a 500 in the logs rather than as a silently empty dialog.

## Checks

`pnpm run test:format`, `pnpm run lint` (0 errors), `tsc --noEmit`, and `pnpm run test` (203 passed) all pass locally.
