### PR TITLE
Document why resolve routes must stay on the edge runtime 📝🌍

### DIFF
--- a/app/api/internal/resolve/arn/route.ts
+++ b/app/api/internal/resolve/arn/route.ts
@@ -1,5 +1,9 @@
 import { handler } from '../base';
 
+// Do not remove: Vercel only honours `preferredRegion` for functions on the edge
+// runtime. Without it this route falls back to the project's default region and
+// silently stops resolving DNS from the location its path name promises.
+// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/preferredRegion
 export const runtime = 'edge';
 export const preferredRegion = 'arn1';
 

--- a/app/api/internal/resolve/bom/route.ts
+++ b/app/api/internal/resolve/bom/route.ts
@@ -1,5 +1,9 @@
 import { handler } from '../base';
 
+// Do not remove: Vercel only honours `preferredRegion` for functions on the edge
+// runtime. Without it this route falls back to the project's default region and
+// silently stops resolving DNS from the location its path name promises.
+// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/preferredRegion
 export const runtime = 'edge';
 export const preferredRegion = 'bom1';
 

--- a/app/api/internal/resolve/cdg/route.ts
+++ b/app/api/internal/resolve/cdg/route.ts
@@ -1,5 +1,9 @@
 import { handler } from '../base';
 
+// Do not remove: Vercel only honours `preferredRegion` for functions on the edge
+// runtime. Without it this route falls back to the project's default region and
+// silently stops resolving DNS from the location its path name promises.
+// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/preferredRegion
 export const runtime = 'edge';
 export const preferredRegion = 'cdg1';
 

--- a/app/api/internal/resolve/cle/route.ts
+++ b/app/api/internal/resolve/cle/route.ts
@@ -1,5 +1,9 @@
 import { handler } from '../base';
 
+// Do not remove: Vercel only honours `preferredRegion` for functions on the edge
+// runtime. Without it this route falls back to the project's default region and
+// silently stops resolving DNS from the location its path name promises.
+// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/preferredRegion
 export const runtime = 'edge';
 export const preferredRegion = 'cle1';
 

--- a/app/api/internal/resolve/cpt/route.ts
+++ b/app/api/internal/resolve/cpt/route.ts
@@ -1,5 +1,9 @@
 import { handler } from '../base';
 
+// Do not remove: Vercel only honours `preferredRegion` for functions on the edge
+// runtime. Without it this route falls back to the project's default region and
+// silently stops resolving DNS from the location its path name promises.
+// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/preferredRegion
 export const runtime = 'edge';
 export const preferredRegion = 'cpt1';
 

--- a/app/api/internal/resolve/dub/route.ts
+++ b/app/api/internal/resolve/dub/route.ts
@@ -1,5 +1,9 @@
 import { handler } from '../base';
 
+// Do not remove: Vercel only honours `preferredRegion` for functions on the edge
+// runtime. Without it this route falls back to the project's default region and
+// silently stops resolving DNS from the location its path name promises.
+// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/preferredRegion
 export const runtime = 'edge';
 export const preferredRegion = 'dub1';
 

--- a/app/api/internal/resolve/fra/route.ts
+++ b/app/api/internal/resolve/fra/route.ts
@@ -1,5 +1,9 @@
 import { handler } from '../base';
 
+// Do not remove: Vercel only honours `preferredRegion` for functions on the edge
+// runtime. Without it this route falls back to the project's default region and
+// silently stops resolving DNS from the location its path name promises.
+// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/preferredRegion
 export const runtime = 'edge';
 export const preferredRegion = 'fra1';
 

--- a/app/api/internal/resolve/gru/route.ts
+++ b/app/api/internal/resolve/gru/route.ts
@@ -1,5 +1,9 @@
 import { handler } from '../base';
 
+// Do not remove: Vercel only honours `preferredRegion` for functions on the edge
+// runtime. Without it this route falls back to the project's default region and
+// silently stops resolving DNS from the location its path name promises.
+// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/preferredRegion
 export const runtime = 'edge';
 export const preferredRegion = 'gru1';
 

--- a/app/api/internal/resolve/hkg/route.ts
+++ b/app/api/internal/resolve/hkg/route.ts
@@ -1,5 +1,9 @@
 import { handler } from '../base';
 
+// Do not remove: Vercel only honours `preferredRegion` for functions on the edge
+// runtime. Without it this route falls back to the project's default region and
+// silently stops resolving DNS from the location its path name promises.
+// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/preferredRegion
 export const runtime = 'edge';
 export const preferredRegion = 'hkg1';
 

--- a/app/api/internal/resolve/hnd/route.ts
+++ b/app/api/internal/resolve/hnd/route.ts
@@ -1,5 +1,9 @@
 import { handler } from '../base';
 
+// Do not remove: Vercel only honours `preferredRegion` for functions on the edge
+// runtime. Without it this route falls back to the project's default region and
+// silently stops resolving DNS from the location its path name promises.
+// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/preferredRegion
 export const runtime = 'edge';
 export const preferredRegion = 'hnd1';
 

--- a/app/api/internal/resolve/iad/route.ts
+++ b/app/api/internal/resolve/iad/route.ts
@@ -1,5 +1,9 @@
 import { handler } from '../base';
 
+// Do not remove: Vercel only honours `preferredRegion` for functions on the edge
+// runtime. Without it this route falls back to the project's default region and
+// silently stops resolving DNS from the location its path name promises.
+// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/preferredRegion
 export const runtime = 'edge';
 export const preferredRegion = 'iad1';
 

--- a/app/api/internal/resolve/icn/route.ts
+++ b/app/api/internal/resolve/icn/route.ts
@@ -1,5 +1,9 @@
 import { handler } from '../base';
 
+// Do not remove: Vercel only honours `preferredRegion` for functions on the edge
+// runtime. Without it this route falls back to the project's default region and
+// silently stops resolving DNS from the location its path name promises.
+// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/preferredRegion
 export const runtime = 'edge';
 export const preferredRegion = 'icn1';
 

--- a/app/api/internal/resolve/kix/route.ts
+++ b/app/api/internal/resolve/kix/route.ts
@@ -1,5 +1,9 @@
 import { handler } from '../base';
 
+// Do not remove: Vercel only honours `preferredRegion` for functions on the edge
+// runtime. Without it this route falls back to the project's default region and
+// silently stops resolving DNS from the location its path name promises.
+// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/preferredRegion
 export const runtime = 'edge';
 export const preferredRegion = 'kix1';
 

--- a/app/api/internal/resolve/lhr/route.ts
+++ b/app/api/internal/resolve/lhr/route.ts
@@ -1,5 +1,9 @@
 import { handler } from '../base';
 
+// Do not remove: Vercel only honours `preferredRegion` for functions on the edge
+// runtime. Without it this route falls back to the project's default region and
+// silently stops resolving DNS from the location its path name promises.
+// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/preferredRegion
 export const runtime = 'edge';
 export const preferredRegion = 'lhr1';
 

--- a/app/api/internal/resolve/pdx/route.ts
+++ b/app/api/internal/resolve/pdx/route.ts
@@ -1,5 +1,9 @@
 import { handler } from '../base';
 
+// Do not remove: Vercel only honours `preferredRegion` for functions on the edge
+// runtime. Without it this route falls back to the project's default region and
+// silently stops resolving DNS from the location its path name promises.
+// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/preferredRegion
 export const runtime = 'edge';
 export const preferredRegion = 'pdx1';
 

--- a/app/api/internal/resolve/sfo/route.ts
+++ b/app/api/internal/resolve/sfo/route.ts
@@ -1,5 +1,9 @@
 import { handler } from '../base';
 
+// Do not remove: Vercel only honours `preferredRegion` for functions on the edge
+// runtime. Without it this route falls back to the project's default region and
+// silently stops resolving DNS from the location its path name promises.
+// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/preferredRegion
 export const runtime = 'edge';
 export const preferredRegion = 'sfo1';
 

--- a/app/api/internal/resolve/sin/route.ts
+++ b/app/api/internal/resolve/sin/route.ts
@@ -1,5 +1,9 @@
 import { handler } from '../base';
 
+// Do not remove: Vercel only honours `preferredRegion` for functions on the edge
+// runtime. Without it this route falls back to the project's default region and
+// silently stops resolving DNS from the location its path name promises.
+// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/preferredRegion
 export const runtime = 'edge';
 export const preferredRegion = 'sin1';
 

--- a/app/api/internal/resolve/syd/route.ts
+++ b/app/api/internal/resolve/syd/route.ts
@@ -1,5 +1,9 @@
 import { handler } from '../base';
 
+// Do not remove: Vercel only honours `preferredRegion` for functions on the edge
+// runtime. Without it this route falls back to the project's default region and
+// silently stops resolving DNS from the location its path name promises.
+// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/preferredRegion
 export const runtime = 'edge';
 export const preferredRegion = 'syd1';
 


### PR DESCRIPTION
## Why

`app/api/internal/resolve/*/route.ts` each pin a Vercel region via `preferredRegion` so DNS gets resolved from that location. That only works because they also set `runtime = 'edge'` — [Vercel only honours `preferredRegion` for edge functions](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/preferredRegion). On the Node.js runtime the export is ignored and the function deploys to the project's default region, so the routes would keep their region-named paths while resolving from the wrong place. Silent, and invisible in tests.

## What

A four-line comment above every `export const runtime = 'edge'` saying exactly that, with a link to the docs. No behaviour change.

## Heads up

Next.js 16.3 deprecates *both* `runtime = 'edge'` and `preferredRegion`, and the deprecation notice just says "remove the export" with no replacement for the pinning use case. This region trick will need a real migration (likely per-function `regions` config on Vercel) before those exports are removed. Not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added inline comments to all `app/api/internal/resolve/*/route.ts` files explaining why `runtime = 'edge'` must stay so `preferredRegion` pins DNS resolution to the correct region. No behavior changes.

- **Migration**
  - `Next.js 16.3` deprecates `runtime = 'edge'` and `preferredRegion`; we should migrate to Vercel per-function `regions` before removing these exports.

<sup>Written for commit 57f0f18080b34ff9c287fa95d00f8cbf75768e48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wotschofsky/domain-digger/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

