### PR TITLE
Convert PostCSS config to ESM to unbreak Turbopack builds 🎨🔧

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-import "./.next/dev/types/root-params.d.ts";
+import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  plugins: {
-    '@tailwindcss/postcss': {},
-  },
-};

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,9 @@
+// ESM on purpose: as CommonJS, Turbopack wraps this in a generated
+// `postcss.config.js_.loader.mjs` that calls a missing async-module helper
+// (`__turbopack_context__.a is not a function`), which fails the build whenever
+// a CSS file actually has to be recompiled. Regressed in Next.js 16.3.0.
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};


### PR DESCRIPTION
## Problem

Production has been failing since the Next.js 16.3 upgrade (`6f743d5`, #100):

```
./node_modules/.../leaflet-defaulticon-compatibility.css
Error evaluating Node.js code
TypeError: __turbopack_context__.a is not a function
  at mod (postcss.config.js_.loader.mjs:11:31)
```

## Why previews looked fine

This is not a production-vs-preview config difference. PR #100's preview (`46a7f74`) and the failing production build (`6f743d5`) have **byte-identical trees** (`726ac573e908...`), the same Next 16.3.0, and the same restored build cache.

| Deploy | Branch / commit | Target | Build cache | Result |
|---|---|---|---|---|
| `87j4wfxs8` | `upgrade-next-16-3` / `46a7f74` | preview | restored | ✅ |
| `r3zq08gzb` | `main` / `6f743d5` | **production** | restored | ❌ 1 error |
| `hjllrschh` | `typescript-7` / `bfa4309` | preview | restored | ✅ |
| `ijkq47qcn` | `instant-navigations` / `b6ad2d3` | preview | restored | ✅ |
| `e118o6scc` | `typescript-7` / `1f97a73` | preview | **skipped** | ❌ 8 errors |

Turbopack only evaluates the PostCSS config when a CSS file actually has to be recompiled, so a warm filesystem build cache (on by default in 16.3) hides the bug. Error count tracks cache coverage: warm → 0, partial → 1, cold → 8.

## Fix

As CommonJS, Turbopack loads the config through a generated `postcss.config.js_.loader.mjs` interop wrapper, and that wrapper calls an async-module helper the Node-side Turbopack runtime doesn't expose in 16.3.0. Declaring the config as ESM skips that wrapper, and is also the form [Tailwind v4 documents](https://tailwindcss.com/docs/installation/using-postcss).

## Verification caveat

A green preview here is **weak evidence** — previews already pass on the broken code. Locally a cold-cache build is green both before and after, so I could not reproduce the failure on macOS/pnpm 10; it needs the Vercel Linux builder. What is confirmed locally is that Tailwind is still applied (76 KB of CSS with `--tw-*` properties), so the ESM config is picked up correctly.

If production still fails after merging, the fallback is pinning back to Next 16.2.6 (last known-green production build) until a 16.3.x patch lands.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch PostCSS config to ESM to bypass Turbopack’s CJS wrapper and fix production build failures on Next.js 16.3. Keeps Tailwind working and restores stable builds.

- **Bug Fixes**
  - Replaced `postcss.config.js` with `postcss.config.mjs` exporting `@tailwindcss/postcss`.
  - Avoids Turbopack interop error: `TypeError: __turbopack_context__.a is not a function`.
  - Updated `next-env.d.ts` imports to `.next/types/...` to remove dev-only paths.

<sup>Written for commit cb55720410f916f88a814b268a3e86f73edb3d0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wotschofsky/domain-digger/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

